### PR TITLE
Remove nl2br from the list of inherited github extensions.

### DIFF
--- a/pymdownx/github.py
+++ b/pymdownx/github.py
@@ -34,7 +34,6 @@ extensions = [
     'pymdownx.tasklist',
     'pymdownx.headeranchor',
     'pymdownx.superfences',
-    'markdown.extensions.nl2br'
 ]
 
 extension_configs = {


### PR DESCRIPTION
Remove `nl2br` from the list of inherited `github` extensions. It does not reflect reality. As an example compare:

* https://github.com/ubuntu-core/snapcraft/blob/master/docs/debug.md
* https://raw.githubusercontent.com/ubuntu-core/snapcraft/master/docs/debug.md

This closes issue #11.