### PR TITLE
Add strip_protocol option to magiclink to hide the http://

### DIFF
--- a/docs/extensions/magiclink.md
+++ b/docs/extensions/magiclink.md
@@ -22,4 +22,9 @@ Just paste links directly in the document like this: https://github.com/faceless
 
 Or even an email address fake.email@email.com.
 
+## Options
+| Option    | Type | Default |Description |
+|-----------|------|---------|------------|
+| hide_protocol | bool | False | If 'True', links are displayed without the initial ftp://, http:// or https:// |
+
 *[GFM]:  Github Flavored Markdown

--- a/pymdownx/magiclink.py
+++ b/pymdownx/magiclink.py
@@ -57,11 +57,14 @@ class MagiclinkPattern(LinkPattern):
         """Handle URL matches."""
 
         el = util.etree.Element("a")
+        el.text = m.group(2)
         if m.group("www"):
             href = "http://%s" % m.group(2)
         else:
             href = m.group(2)
-        el.text = m.group(2)
+            if self.config['hide_protocol']:
+                el.text = el.text[el.text.find("://") + 3:]
+
         el.set("href", self.sanitize_url(self.unescape(href.strip())))
 
         return el
@@ -84,10 +87,24 @@ class MagicMailPattern(LinkPattern):
 class MagiclinkExtension(Extension):
     """Add Easylink extension to Markdown class."""
 
+    def __init__(self, *args, **kwargs):
+        """Initialize."""
+
+        self.config = {
+            'hide_protocol': [
+                False,
+                "If 'True', links are displayed without the initial ftp://, http:// or https://"
+                "- Default: False"
+            ]
+        }
+        super(MagiclinkExtension, self).__init__(*args, **kwargs)
+
     def extendMarkdown(self, md, md_globals):
         """Add support for turning html links and emails to link tags."""
 
-        md.inlinePatterns.add("magic-link", MagiclinkPattern(RE_LINK, md), "<not_strong")
+        link_pattern = MagiclinkPattern(RE_LINK, md)
+        link_pattern.config = self.getConfigs()
+        md.inlinePatterns.add("magic-link", link_pattern, "<not_strong")
         md.inlinePatterns.add("magic-mail", MagicMailPattern(RE_MAIL, md), "<not_strong")
 
 

--- a/tests/extensions/magiclink_hide_protocol.html
+++ b/tests/extensions/magiclink_hide_protocol.html
@@ -1,0 +1,4 @@
+<p><a href="http://foo.com/blah_blah_(wikipedia)_(again">foo.com/blah_blah_(wikipedia)_(again</a>)</p>
+<p><a href="https://www.example.com/foo/?bar=baz&amp;inga=42&amp;quux">www.example.com/foo/?bar=baz&amp;inga=42&amp;quux</a></p>
+<p><a href="ftp://foo.bar/baz">foo.bar/baz</a></p>
+<p><a href="mailto:mailto@unaffected.org">mailto@unaffected.org</a></p>

--- a/tests/extensions/magiclink_hide_protocol.txt
+++ b/tests/extensions/magiclink_hide_protocol.txt
@@ -1,0 +1,7 @@
+http://foo.com/blah_blah_(wikipedia)_(again)
+
+https://www.example.com/foo/?bar=baz&inga=42&quux
+
+ftp://foo.bar/baz
+
+mailto@unaffected.org

--- a/tests/extensions/tests.yml
+++ b/tests/extensions/tests.yml
@@ -100,6 +100,12 @@ inlinehilite_plaintext:
 magiclink:
   extensions:
     pymdownx.magiclink:
+      hide_protocol: false
+
+magiclink_hide_protocol:
+  extensions:
+    pymdownx.magiclink:
+      hide_protocol: true
 
 mark:
   extensions:


### PR DESCRIPTION
so now you can use pymdownx.magiclink(strip_protocol=True) if you want your links to be displayed as [github.com](https://github.com) rather than [https://github.com](https://github.com)

Tests and docs updated.

Not certain if anybody else wants this. Obviously this feature is non-urgent.