### PR TITLE
Add better support for styling task lists

### DIFF
--- a/pymdownx/tasklist.py
+++ b/pymdownx/tasklist.py
@@ -34,7 +34,7 @@ RE_CHECKBOX = re.compile(r"^(?P<checkbox> *\[(?P<state>(?:x|X| ){1})\] +)(?P<lin
 def get_checkbox(state):
     """Get checkbox tag."""
 
-    return '<input type="checkbox" disabled%s> ' % (' checked' if state.lower() == 'x' else '')
+    return '<input type="checkbox" disabled%s><label></label> ' % (' checked' if state.lower() == 'x' else '')
 
 
 class TasklistTreeprocessor(Treeprocessor):

--- a/tests/extensions/tasklist.html
+++ b/tests/extensions/tasklist.html
@@ -7,31 +7,31 @@
 <div class="markdown-body">
 <h1>Task List</h1>
 <ul class="task-list">
-<li class="task-list-item"><input type="checkbox" disabled checked> item 1<ul class="task-list">
-<li class="task-list-item"><input type="checkbox" disabled checked> item A</li>
-<li class="task-list-item"><input type="checkbox" disabled> item B<ul class="task-list">
-<li class="task-list-item"><input type="checkbox" disabled checked> item a</li>
-<li class="task-list-item"><input type="checkbox" disabled> item b</li>
-<li class="task-list-item"><input type="checkbox" disabled checked> item c</li>
+<li class="task-list-item"><input type="checkbox" disabled checked><label></label> item 1<ul class="task-list">
+<li class="task-list-item"><input type="checkbox" disabled checked><label></label> item A</li>
+<li class="task-list-item"><input type="checkbox" disabled><label></label> item B<ul class="task-list">
+<li class="task-list-item"><input type="checkbox" disabled checked><label></label> item a</li>
+<li class="task-list-item"><input type="checkbox" disabled><label></label> item b</li>
+<li class="task-list-item"><input type="checkbox" disabled checked><label></label> item c</li>
 </ul>
 </li>
-<li class="task-list-item"><input type="checkbox" disabled checked> item C</li>
+<li class="task-list-item"><input type="checkbox" disabled checked><label></label> item C</li>
 </ul>
 </li>
-<li class="task-list-item"><input type="checkbox" disabled> item 2</li>
-<li class="task-list-item"><input type="checkbox" disabled> item 3</li>
+<li class="task-list-item"><input type="checkbox" disabled><label></label> item 2</li>
+<li class="task-list-item"><input type="checkbox" disabled><label></label> item 3</li>
 </ul>
 <h1>Mixed Lists</h1>
 <ul>
 <li>item 1<ul class="task-list">
-<li class="task-list-item"><input type="checkbox" disabled checked> item A</li>
-<li class="task-list-item"><input type="checkbox" disabled> item B<ol>
+<li class="task-list-item"><input type="checkbox" disabled checked><label></label> item A</li>
+<li class="task-list-item"><input type="checkbox" disabled><label></label> item B<ol>
 <li>item a</li>
 <li>item b</li>
 <li>item c</li>
 </ol>
 </li>
-<li class="task-list-item"><input type="checkbox" disabled checked> item C</li>
+<li class="task-list-item"><input type="checkbox" disabled checked><label></label> item C</li>
 </ul>
 </li>
 <li>item 2</li>
@@ -40,27 +40,27 @@
 <h1>Really Mixed Lists</h1>
 <ul class="task-list">
 <li>item 1<ul class="task-list">
-<li class="task-list-item"><input type="checkbox" disabled checked> item A</li>
+<li class="task-list-item"><input type="checkbox" disabled checked><label></label> item A</li>
 <li>item B
     more text<ol class="task-list">
 <li>item a</li>
 <li>item b</li>
-<li class="task-list-item"><input type="checkbox" disabled> item c</li>
+<li class="task-list-item"><input type="checkbox" disabled><label></label> item c</li>
 </ol>
 </li>
 <li>item C</li>
 </ul>
 </li>
 <li>item 2</li>
-<li class="task-list-item"><input type="checkbox" disabled checked> item 3</li>
+<li class="task-list-item"><input type="checkbox" disabled checked><label></label> item 3</li>
 </ul>
 <h1>Test Tasklists in Subparagraphs</h1>
 <ul class="task-list">
 <li class="task-list-item">
-<p><input type="checkbox" disabled checked> item 1</p>
+<p><input type="checkbox" disabled checked><label></label> item 1</p>
 <ul class="task-list">
 <li class="task-list-item">
-<p><input type="checkbox" disabled checked> item A</p>
+<p><input type="checkbox" disabled checked><label></label> item A</p>
 </li>
 <li>
 <p>item a</p>


### PR DESCRIPTION
The generated source makes it impossible to style checkboxes with custom images or webfonts with pseudo elements, as they are not supported by the CSS specification on input elements.

Placing an empty label next to a checkbox makes this possible, see here:
http://stackoverflow.com/questions/3772273/pure-css-checkbox-image-replacement

An empty label takes no space, as it is an inline element by default. Would be great if this would make it into master, because I would like to incorporate Material Design styled checkboxes into my MkDocs theme: https://github.com/squidfunk/mkdocs-material