### PR TITLE
Fix critic viewing issues

### DIFF
--- a/pymdownx/critic.py
+++ b/pymdownx/critic.py
@@ -312,7 +312,7 @@ class CriticExtension(Extension):
         critic = CriticViewPreprocessor(self.critic_stash)
         critic.config = self.getConfigs()
         md.preprocessors.add('critic', critic, ">normalize_whitespace")
-        md.postprocessors.add("critic-post", post, "<raw_html")
+        md.postprocessors.add("critic-post", post, ">raw_html")
 
     def reset(self):
         """
@@ -326,7 +326,7 @@ class CriticExtension(Extension):
         if not self.configured:
             self.configured = True
             self.md.preprocessors.link('critic', '>normalize_whitespace')
-            self.md.postprocessors.link('critic-post', '<raw_html')
+            self.md.postprocessors.link('critic-post', '>raw_html')
         self.critic_stash.clear()
 
 

--- a/pymdownx/escapeall.py
+++ b/pymdownx/escapeall.py
@@ -30,6 +30,9 @@ from markdown import util as md_util
 import re
 from . import util
 
+# We need to ignore theseas they are used in Markdown processing
+STX = '\u0002'
+ETX = '\u0003'
 ESCAPE_RE = r'\\(.)'
 ESCAPE_NO_NL_RE = r'\\([^\n])'
 HARDBREAK_RE = r'\\\n'
@@ -51,6 +54,8 @@ class EscapeAllPattern(Pattern):
         char = m.group(2)
         if self.nbsp and char == ' ':
             escape = md_util.AMP_SUBSTITUTE + 'nbsp;'
+        elif char in (STX, ETX):
+            escape = char
         else:
             escape = '%s%s%s' % (md_util.STX, util.get_ord(char), md_util.ETX)
         return escape


### PR DESCRIPTION
- Don’t process critic tag insertions until after `raw_html` post
processor has finished so we don’t miss any critic tags.
- EscapeAll needs to ignore STX and ETX characters as Python Markdown
(and particularly Critic) uses them to insert placeholders.  Instead
when \[STX] is present, instead of escaping the character, just insert
the real character back: [STX].

fixes #95