### PR TITLE
Support shorthand links for external repositories

### DIFF
--- a/docs/src/markdown/changelog.md
+++ b/docs/src/markdown/changelog.md
@@ -4,7 +4,7 @@
 
 Nov X, 2017
 
-- **NEW**: Shorthand format for referencing non-default provider commits, issues, pulls, and mentions (!145).
+- **NEW**: Shorthand format for referencing non-default provider commits, issues, pulls, and mentions (!147).
 
 ## 4.2.0
 

--- a/docs/src/markdown/changelog.md
+++ b/docs/src/markdown/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 4.3.0
+
+Nov X, 2017
+
+- **NEW**: Shorthand format for referencing non-default provider commits, issues, pulls, and mentions (!145).
+
 ## 4.2.0
 
 Nov 13, 2017

--- a/docs/src/markdown/extensions/magiclink.md
+++ b/docs/src/markdown/extensions/magiclink.md
@@ -30,34 +30,46 @@ To use this feature you must configure MagicLink for your desired provider and s
 
 All shorthand links will be relative to your `provider`, and they do not currently work cross provider. So if your `provider` is set to `github`, all mentions will be generated for GitHub.  If a user name or repository is not specified, the link will use the values found in `user` and `repo` from the extension's [options](#options).
 
-Mentions of other users are performed with the following syntax: `@{user}`.
-
-Issues and pull requests are specified with `#{num}` and `!{num}` respectively. To specify an issue for a non-default repository under the default user, prefix the repository: `{repo}#{num}`. And to specify a repository under a non-default user, prefix both the user and repository: `{user}/{repo}#{num}`.
-
-Commit shorthand syntax is simply the 40 character commit hash value: `{hash}`. And much like issues and pull requests, you can denote a repository under the default user with `{repo}@{hash}` and a repository under a non-default user with `{user}/{repo}@{hash}`.
-
-For reference, the examples below assume the default provider, user, and repository as `github`, `facelessuer`, and `pymdown-extensions` respectively.
-
-Shorthand                                            | Output
----------------------------------------------------- | -----------
-`@user`                                              | @user                                              |Mention another user under your `provider`.
-`#1`                                                 | #1                                                 |Issue for the default `user` and `repo`.
-`repo#1`                                             | repo#1                                             |Issue for a specific project under the default `user`.
-`user/repo#1`                                        | user/repo#1                                        |Issue for a specific user and repository.
-`!2`                                                 | !2                                                 |Pull request for the default `user` and `repo`.
-`repo!2`                                             | repo!2                                             |Pull request for a specific project under the default `user`.
-`user/repo!2`                                        | user/repo!2                                        |Pull request for a specific user and repository.
-`181c06d1f11fa29961b334e90606ed1f1ec7a7cc`           | 181c06d1f11fa29961b334e90606ed1f1ec7a7cc           |Commit for the default `user` and `repo`.
-`repo@181c06d1f11fa29961b334e90606ed1f1ec7a7cc`      | repo@181c06d1f11fa29961b334e90606ed1f1ec7a7cc      |Commit for a specific project under the default `user`.
-`user/repo@181c06d1f11fa29961b334e90606ed1f1ec7a7cc` | user/repo@181c06d1f11fa29961b334e90606ed1f1ec7a7cc |Commit for a specific user and repository.
-
 !!! warning
-    Links are not be verified, so make sure you are specifying valid issues, repositories, and users as they will be auto-linked even if they are not valid.
+    Links are not verified, so make sure you are specifying valid issues, repositories, and users as they will be auto-linked even if they are not valid.
+
+### Mentions
+
+Mentions of other users are performed with the following syntax: `@{user}`. To reference an external provider, use the format `@{provider}:{user}`
+
+### Issues and Pull Requests
+
+Issues and pull requests are specified with `#{num}` and `!{num}` respectively. To specify an issue for a non-default repository under the default user, prefix the repository: `{repo}#{num}`. And to specify a repository under a non-default user, prefix both the user and repository: `{user}/{repo}#{num}`. And to reference an external provider, use the format `{provider}:{user}/{repo}#{num}`.
 
 !!! note "Note"
     GitHub actually gives pull requests and issues unique values while GitLab and Bitbucket can have pulls with the same ID as an issue. So with GitHub, you can use `#{num}` format for both issues and pulls, and GitHub will redirect you to the appropriate issue or pull.
 
     GitLab and Bitbucket **must** specify pulls different from issues, hence the `!13` format. Though GitHub doesn't *need* to use the pull format, you can if you like. This format was actually borrowed from GitLab.
+
+### Commits
+
+Commit shorthand syntax is simply the 40 character commit hash value: `{hash}`. And much like issues and pull requests, you can denote a repository under the default user with `{repo}@{hash}` and a repository under a non-default user with `{user}/{repo}@{hash}`. Lastly, to reference an external provider, use the format `{provider}:{user}/{repo}@{hash}`.
+
+### Shorthand Examples
+
+The examples below assume the default provider, user, and repository as `github`, `facelessuer`, and `pymdown-extensions` respectively.
+
+Shorthand                                                      | Output
+-------------------------------------------------------------- | -----------
+`@user`                                                        | @user
+`@gitlab:user`                                                 | @gitlab:user
+`#1`                                                           | #1
+`repo#1`                                                       | repo#1
+`bitbucket:user/repo#1`                                        | bitbucket:user/repo#1
+`user/repo#1`                                                  | user/repo#1
+`!2`                                                           | !2
+`repo!2`                                                       | repo!2
+`user/repo!2`                                                  | user/repo!2
+`gitlab:user/repo!1`                                           | gitlab:user/repo!1
+`181c06d1f11fa29961b334e90606ed1f1ec7a7cc`                     | 181c06d1f11fa29961b334e90606ed1f1ec7a7cc
+`repo@181c06d1f11fa29961b334e90606ed1f1ec7a7cc`                | repo@181c06d1f11fa29961b334e90606ed1f1ec7a7cc
+`user/repo@181c06d1f11fa29961b334e90606ed1f1ec7a7cc`           | user/repo@181c06d1f11fa29961b334e90606ed1f1ec7a7cc
+`bitbucket:user/repo@181c06d1f11fa29961b334e90606ed1f1ec7a7cc` | bitbucket:user/repo@181c06d1f11fa29961b334e90606ed1f1ec7a7cc
 
 ## Repository Link Shortener
 

--- a/pymdownx/__version__.py
+++ b/pymdownx/__version__.py
@@ -1,7 +1,7 @@
 """Version."""
 
 #   (major, minor, micro, release type, pre-release build, post-release build)
-version_info = (4, 2, 0, 'final', 0, 0)
+version_info = (4, 3, 0, 'final', 0, 0)
 
 
 def _version():

--- a/tests/extensions/magiclink/magiclink (legacy).html
+++ b/tests/extensions/magiclink/magiclink (legacy).html
@@ -14,3 +14,4 @@
 <p><a class="magiclink magiclink-commit" href="https://bitbucket.org/fake-user/fake-repository/commits/commit/594b25d53798c30735da5a9be19c06cc94052a16" title="Bitbucket Commit: fake-user/fake-repository@594b25d">fake-user/fake-repository@594b25d</a></p>
 <p><a class="magiclink magiclink-issue" href="https://github.com/facelessuser/pymdown-extensions/issues/49" title="GitHub Issue: facelessuser/pymdown-extensions#49">#49</a></p>
 <p><a class="magiclink magiclink-issue" href="https://github.com/facelessuser/fake-repository/issues/87" title="GitHub Issue: facelessuser/fake-repository#87">fake-repository#87</a></p>
+<p><a class="magiclink magiclink-commit" href="https://github.com/facelessuser/fake-repository/commit/594b25d53798c30735da5a9be19c06cc94052a16" title="GitHub Commit: facelessuser/fake-repository@594b25d">fake-repository@594b25d</a></p>

--- a/tests/extensions/magiclink/magiclink (legacy).txt
+++ b/tests/extensions/magiclink/magiclink (legacy).txt
@@ -29,3 +29,5 @@ https://bitbucket.org/fake-user/fake-repository/commits/commit/594b25d53798c3073
 <https://github.com/facelessuser/pymdown-extensions/issues/49>
 
 https://github.com/facelessuser/fake-repository/issues/87
+
+https://github.com/facelessuser/fake-repository/commit/594b25d53798c30735da5a9be19c06cc94052a16

--- a/tests/extensions/magiclink/magiclink (shorthand).html
+++ b/tests/extensions/magiclink/magiclink (shorthand).html
@@ -8,6 +8,10 @@
 <p>Commit <a class="magiclink magiclink-commit" href="https://github.com/facelessuser/MyRepo/commit/3f6b07a8eeaa9d606115758d90f55fec565d4e2a" title="GitHub Commit: facelessuser/MyRepo@3f6b07a">MyRepo@3f6b07a</a></p>
 <p>Issue <a class="magiclink magiclink-issue" href="https://github.com/facelessuser/MyRepo/issues/33" title="GitHub Issue: facelessuser/MyRepo#33">MyRepo#33</a></p>
 <p>Pull <a class="magiclink magiclink-pull" href="https://github.com/facelessuser/MyRepo/pull/33" title="GitHub Pull Request: facelessuser/MyRepo!33">MyRepo!33</a></p>
+<p>Mention <a class="magiclink magiclink-mention" href="https://gitlab.com/some-user" title="GitLab User: some-user">@some-user</a></p>
+<p>Issue <a class="magiclink magiclink-issue" href="https://github.com/some-user/some-repo/issues/1" title="GitHub Issue: some-user/some-repo#1">some-user/some-repo#1</a></p>
+<p>Pull request <a class="magiclink magiclink-pull" href="https://bitbucket.org/some-user/some-repo/pull-requests/2" title="Bitbucket Pull Request: some-user/some-repo!2">some-user/some-repo!2</a></p>
+<p>Commit <a class="magiclink magiclink-commit" href="https://gitlab.com/some-user/some-repo/commit/3f6b07a8eeaa9d606115758d90f55fec565d4e2a" title="GitLab Commit: some-user/some-repo@3f6b07a8">some-user/some-repo@3f6b07a8</a></p>
 <p>No issue #33</p>
 <p>No pull request !33</p>
 <p>No mention @some-bodies_name</p>

--- a/tests/extensions/magiclink/magiclink (shorthand).txt
+++ b/tests/extensions/magiclink/magiclink (shorthand).txt
@@ -18,6 +18,14 @@ Issue MyRepo#33
 
 Pull MyRepo!33
 
+Mention @gitlab:some-user
+
+Issue github:some-user/some-repo#1
+
+Pull request bitbucket:some-user/some-repo!2
+
+Commit gitlab:some-user/some-repo@3f6b07a8eeaa9d606115758d90f55fec565d4e2a
+
 No issue \#33
 
 No pull request \!33

--- a/tests/extensions/magiclink/magiclink.html
+++ b/tests/extensions/magiclink/magiclink.html
@@ -125,3 +125,4 @@
 <p><a class="magiclink magiclink-commit" href="https://bitbucket.org/fake-user/fake-repository/commits/commit/594b25d53798c30735da5a9be19c06cc94052a16" title="Bitbucket Commit: fake-user/fake-repository@594b25d">fake-user/fake-repository@594b25d</a></p>
 <p><a class="magiclink magiclink-issue" href="https://github.com/facelessuser/pymdown-extensions/issues/49" title="GitHub Issue: facelessuser/pymdown-extensions#49">#49</a></p>
 <p><a class="magiclink magiclink-issue" href="https://github.com/facelessuser/fake-repository/issues/87" title="GitHub Issue: facelessuser/fake-repository#87">fake-repository#87</a></p>
+<p><a class="magiclink magiclink-commit" href="https://github.com/facelessuser/fake-repository/commit/594b25d53798c30735da5a9be19c06cc94052a16" title="GitHub Commit: facelessuser/fake-repository@594b25d">fake-repository@594b25d</a></p>

--- a/tests/extensions/magiclink/magiclink.txt
+++ b/tests/extensions/magiclink/magiclink.txt
@@ -249,3 +249,5 @@ https://bitbucket.org/fake-user/fake-repository/commits/commit/594b25d53798c3073
 <https://github.com/facelessuser/pymdown-extensions/issues/49>
 
 https://github.com/facelessuser/fake-repository/issues/87
+
+https://github.com/facelessuser/fake-repository/commit/594b25d53798c30735da5a9be19c06cc94052a16


### PR DESCRIPTION
Ref #146 

Allow using shorthand by prefixing `user` with `provider:`.

| Shorthand
| ----------
| `@gitlab:user`
| `bitbucket:user/repo#1`
| `gitlab:user/repo!1`
| `bitbucket:user/repo@181c06d1f11fa29961b334e90606ed1f1ec7a7cc`