### PR TITLE
Fix invalid link defaults

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,6 @@ matrix:
   include:
   - python: 2.7
     env: TOXENV=py27-unittests
-  - python: 3.3
-    env: TOXENV=py33-unittests
   - python: 3.4
     env: TOXENV=py34-unittests
   - python: 3.5

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,8 +6,6 @@ environment:
   matrix:
     - PYTHON: "C:/Python27"
       TOXENV: "py27-unittests"
-    - PYTHON: "C:/Python33"
-      TOXENV: "py33-unittests"
     - PYTHON: "C:/Python34"
       TOXENV: "py34-unittests"
     - PYTHON: "C:/Python35"

--- a/docs/src/markdown/changelog.md
+++ b/docs/src/markdown/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 4.5.1
+
+Nov 28, 2017
+
+- **FIX**: If an invalid provider is given, default to `github`. If no `user` or `repo` is specified, do not convert links that depend on those default values (#169).
+
 ## 4.5.0
 
 Nov 26, 2017

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pymdown-extensions",
-  "version": "4.5.0",
+  "version": "4.5.1",
   "description": "Extensions for Python Markdown",
   "repository": "https://github.com/facelessuser/pymdown-extensions.git",
   "author": "Isaac Muse <isaacmuse@gmail.com>",

--- a/pymdownx/__version__.py
+++ b/pymdownx/__version__.py
@@ -1,7 +1,7 @@
 """Version."""
 
 #   (major, minor, micro, release type, pre-release build, post-release build)
-version_info = (4, 5, 0, 'final', 0, 0)
+version_info = (4, 5, 1, 'final', 0, 0)
 
 
 def _version():

--- a/tests/extensions/magiclink/magiclink (invalid).html
+++ b/tests/extensions/magiclink/magiclink (invalid).html
@@ -1,0 +1,22 @@
+<p>Mention <a class="magiclink magiclink-github magiclink-mention" href="https://github.com/some-bodies_name" title="GitHub User: some-bodies_name">@some-bodies_name</a></p>
+<p>Mention <a class="magiclink magiclink-github magiclink-repository" href="https://github.com/some-bodies_name/some_repository" title="GitHub Repository: some-bodies_name/some_repository">some-bodies_name/some_repository</a></p>
+<p>Mention <a class="magiclink magiclink-github magiclink-repository" href="https://github.com/facelessuser/some_repository" title="GitHub Repository: facelessuser/some_repository">facelessuser/some_repository</a></p>
+<p>Commit <a class="magiclink magiclink-github magiclink-commit" href="https://github.com/some-bodies_name/some_repository/commit/3f6b07a8eeaa9d606115758d90f55fec565d4e2a" title="GitHub Commit: some-bodies_name/some_repository@3f6b07a">some-bodies_name/some_repository@3f6b07a</a></p>
+<p>Compare <a class="magiclink magiclink-github magiclink-compare" href="https://github.com/some-bodies_name/some_repository/compare/e2ed7e0b3973f3f9eb7a26b8ef7ae514eebfe0d2...90b6fb8711e75732f987982cc024e9bb0111beac" title="GitHub Compare: some-bodies_name/some_repository@e2ed7e0...90b6fb8">some-bodies_name/some_repository@e2ed7e0...90b6fb8</a></p>
+<p>Issue <a class="magiclink magiclink-github magiclink-issue" href="https://github.com/some-bodies_name/some_repository/issues/33" title="GitHub Issue: some-bodies_name/some_repository#33">some-bodies_name/some_repository#33</a></p>
+<p>Pull request <a class="magiclink magiclink-github magiclink-pull" href="https://github.com/some-bodies_name/some_repository/pull/33" title="GitHub Pull Request: some-bodies_name/some_repository!33">some-bodies_name/some_repository!33</a></p>
+<p>Commit Commit 3f6b07a8eeaa9d606115758d90f55fec565d4e2a</p>
+<p>Compare Compare e2ed7e0b3973f3f9eb7a26b8ef7ae514eebfe0d2...90b6fb8711e75732f987982cc024e9bb0111beac</p>
+<p>Issue Issue #33</p>
+<p>Pull request Pull request !33</p>
+<p>Commit Commit MyRepo@3f6b07a8eeaa9d606115758d90f55fec565d4e2a</p>
+<p>Compare Compare MyRepo@e2ed7e0b3973f3f9eb7a26b8ef7ae514eebfe0d2...90b6fb8711e75732f987982cc024e9bb0111beac</p>
+<p>Issue Issue MyRepo#33</p>
+<p>Pull Pull MyRepo!33</p>
+<p>Mention <a class="magiclink magiclink-gitlab magiclink-mention" href="https://gitlab.com/some-user" title="GitLab User: some-user">@some-user</a></p>
+<p>Mention <a class="magiclink magiclink-gitlab magiclink-repository" href="https://gitlab.com/some-bodies_name/some_repository" title="GitLab Repository: some-bodies_name/some_repository">some-bodies_name/some_repository</a></p>
+<p>Mention <a class="magiclink magiclink-bitbucket magiclink-repository" href="https://bitbucket.org/facelessuser/some_repository" title="Bitbucket Repository: facelessuser/some_repository">facelessuser/some_repository</a></p>
+<p>Issue <a class="magiclink magiclink-github magiclink-issue" href="https://github.com/some-user/some-repo/issues/1" title="GitHub Issue: some-user/some-repo#1">some-user/some-repo#1</a></p>
+<p>Pull request <a class="magiclink magiclink-bitbucket magiclink-pull" href="https://bitbucket.org/some-user/some-repo/pull-requests/2" title="Bitbucket Pull Request: some-user/some-repo!2">some-user/some-repo!2</a></p>
+<p>Commit <a class="magiclink magiclink-gitlab magiclink-commit" href="https://gitlab.com/some-user/some-repo/commit/3f6b07a8eeaa9d606115758d90f55fec565d4e2a" title="GitLab Commit: some-user/some-repo@3f6b07a8">some-user/some-repo@3f6b07a8</a></p>
+<p>Compare <a class="magiclink magiclink-gitlab magiclink-compare" href="https://gitlab.com/some-user/some-repo/compare/e2ed7e0b3973f3f9eb7a26b8ef7ae514eebfe0d2...90b6fb8711e75732f987982cc024e9bb0111beac" title="GitLab Compare: some-user/some-repo@e2ed7e0b...90b6fb87">some-user/some-repo@e2ed7e0b...90b6fb87</a></p>

--- a/tests/extensions/magiclink/magiclink (invalid).txt
+++ b/tests/extensions/magiclink/magiclink (invalid).txt
@@ -1,0 +1,43 @@
+Mention @some-bodies_name
+
+Mention @some-bodies_name/some_repository
+
+Mention @facelessuser/some_repository
+
+Commit some-bodies_name/some_repository@3f6b07a8eeaa9d606115758d90f55fec565d4e2a
+
+Compare some-bodies_name/some_repository@e2ed7e0b3973f3f9eb7a26b8ef7ae514eebfe0d2...90b6fb8711e75732f987982cc024e9bb0111beac
+
+Issue some-bodies_name/some_repository#33
+
+Pull request some-bodies_name/some_repository!33
+
+Commit 3f6b07a8eeaa9d606115758d90f55fec565d4e2a
+
+Compare e2ed7e0b3973f3f9eb7a26b8ef7ae514eebfe0d2...90b6fb8711e75732f987982cc024e9bb0111beac
+
+Issue #33
+
+Pull request !33
+
+Commit MyRepo@3f6b07a8eeaa9d606115758d90f55fec565d4e2a
+
+Compare MyRepo@e2ed7e0b3973f3f9eb7a26b8ef7ae514eebfe0d2...90b6fb8711e75732f987982cc024e9bb0111beac
+
+Issue MyRepo#33
+
+Pull MyRepo!33
+
+Mention @gitlab:some-user
+
+Mention @gitlab:some-bodies_name/some_repository
+
+Mention @bitbucket:facelessuser/some_repository
+
+Issue github:some-user/some-repo#1
+
+Pull request bitbucket:some-user/some-repo!2
+
+Commit gitlab:some-user/some-repo@3f6b07a8eeaa9d606115758d90f55fec565d4e2a
+
+Compare gitlab:some-user/some-repo@e2ed7e0b3973f3f9eb7a26b8ef7ae514eebfe0d2...90b6fb8711e75732f987982cc024e9bb0111beac

--- a/tests/extensions/magiclink/tests.yml
+++ b/tests/extensions/magiclink/tests.yml
@@ -44,6 +44,15 @@ magiclink (gitlab):
       user: facelessuser
       repo: pymdown-extensions
 
+magiclink (invalid):
+  extensions:
+    pymdownx.magiclink:
+      hide_protocol: false
+      provider: invalid
+      repo_url_shortener: true
+      repo_url_shorthand: true
+      social_url_shorthand: true
+
 magiclink (legacy):
   extensions:
     pymdownx.magiclink:

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    {py27,py33,py34,py35,py36}-unittests, lint, spelling
+    {py27,py34,py35,py36}-unittests, lint, spelling
 
 [testenv]
 passenv = LANG


### PR DESCRIPTION
If an invalid provider is given, default to `github`. If no `user` or `repo` is specified, do not convert links that depend on those default values. Ref #169.