### PR TITLE
Increase required Markdown version to 2.6.10

### DIFF
--- a/requirements/project.txt
+++ b/requirements/project.txt
@@ -1,1 +1,1 @@
-Markdown>=2.6.0
+Markdown>=2.6.10


### PR DESCRIPTION
The magiclink extension uses ancestry exclusion to prevent auto-linking
when text is already inside a link. Support for this was only added
to Markdown in version 2.6.10 (see Python-Markdown/markdown#598).