### PR TITLE
Make the build fail when a snippet cannot be found

### DIFF
--- a/docs/src/markdown/extensions/snippets.md
+++ b/docs/src/markdown/extensions/snippets.md
@@ -77,7 +77,8 @@ file2.md
 
 ## Options
 
-Option      | Type   | Default        | Description
------------ | ------ | -------------- |------------
-`base_path` | string | `#!py3 '.'`     | A string indicating a base path to be used resolve snippet locations.
-`encoding`  | string | `#!py3 'utf-8'` | Encoding to use when reading in the snippets.
+Option         | Type   | Default         | Description
+-------------- | ------ | --------------- |------------
+`base_path`    | string | `#!py3 '.'`     | A string indicating a base path to be used resolve snippet locations.
+`encoding`     | string | `#!py3 'utf-8'` | Encoding to use when reading in the snippets.
+`check_paths`  | bool   | `#!py3 false`   | Make the build fail if a snippet can't be found.

--- a/tests/test_targeted.py
+++ b/tests/test_targeted.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 from pymdownx import util
 import unittest
 import pytest
+import markdown
 
 
 class TestUrlParse(unittest.TestCase):
@@ -138,6 +139,41 @@ class TestUrlParse(unittest.TestCase):
         self.assertEqual(path, '..\\file\\path')
         self.assertEqual(is_url, False)
         self.assertEqual(is_absolute, False)
+
+
+class TestSnippets(unittest.TestCase):
+    """Targeted tests for Snippets."""
+
+    def test_bad_file_checked(self):
+        """Test bad file when the check is enabled."""
+        with self.assertRaises(Exception):
+            markdown.Markdown(
+                extensions=['pymdownx.snippets'],
+                extension_configs={'pymdownx.snippets': {'check_paths': True}}
+            ).convert('--8<--- "bad.file"')
+
+    def test_good_file_checked(self):
+        """Test good file when the check is enabled."""
+        expected = "<p>Snippet</p>"
+        rendered = markdown.Markdown(
+            extensions=['pymdownx.snippets'],
+            extension_configs={'pymdownx.snippets': {
+                'check_paths': True,
+                'base_path': 'tests/extensions/_snippets'
+            }}
+        ).convert('--8<--- "d.txt"')
+
+        self.assertEqual(expected, rendered)
+
+    def test_bad_file_unchecked(self):
+        """Test bad file when the check is disabled."""
+        expected = ""
+        rendered = markdown.Markdown(
+            extensions=['pymdownx.snippets'],
+            extension_configs={'pymdownx.snippets': {'check_paths': False}}
+        ).convert('--8<--- "bad.file"')
+
+        self.assertEqual(expected, rendered)
 
 
 def run():


### PR DESCRIPTION
Hello,

I recently started using the snippet extension at work, fantastic little thing!
People were concerned that there might be problems long term because it did not make the build fail when a snippet can't be found, like what happens in mkdocs when linking to a file that doesn't exist. It actually happened fairly quickly, and we patched the extension to avoid us some headache in the future, so here is a 2 line backport if you want it!

Not sure how to test it though, I haven't found examples of builds that are meant to fail in the tests, ideas?