### PR TITLE
fix path conversion protocol

### DIFF
--- a/pymdownx/pathconverter.py
+++ b/pymdownx/pathconverter.py
@@ -81,6 +81,9 @@ def repl_relative(m, base_path, relative_path):
                 )
                 # Convert the path, url encode it, and format it as a link
                 path = util.pathname2url(path)
+                # If on windows, replace the notation to use a default protocol `///` with nothing.
+                if util.is_win() and path.startswith('///'):
+                    path = path.replace('///', '', 1)
                 link = '%s"%s"' % (m.group('name'), util.urlunparse((scheme, netloc, path, params, query, fragment)))
     except Exception:  # pragma: no cover
         # Parsing crashed and burned; no need to continue.
@@ -100,6 +103,9 @@ def repl_absolute(m, base_path):
             path = util.url2pathname(path)
             path = os.path.normpath(os.path.join(base_path, path))
             path = util.pathname2url(path)
+            # If on windows, replace the notation to use a default protocol `///` with nothing.
+            if util.is_win() and path.startswith('///'):
+                path = path.replace('///', '', 1)
             link = '%s"%s"' % (m.group('name'), util.urlunparse((scheme, netloc, path, params, query, fragment)))
     except Exception:  # pragma: no cover
         # Parsing crashed and burned; no need to continue.

--- a/tests/test_extensions/test_pathconverter.py
+++ b/tests/test_extensions/test_pathconverter.py
@@ -258,7 +258,7 @@ class TestWindows(util.MdCase):
         if util.is_win():
             self.check_markdown(
                 r'![picture](./extensions/_assets/bg.png)',
-                r'<p><img alt="picture" src="///C:/Some/fake/path/extensions/_assets/bg.png" /></p>'
+                r'<p><img alt="picture" src="C:/Some/fake/path/extensions/_assets/bg.png" /></p>'
             )
         else:
             self.check_markdown(


### PR DESCRIPTION
On Windows, we will use the notation `///c:/path` when converting an an absolute drive path to a URL.  `//` means use the current default protocol.  This isn't necessarily correct in the way we are using it.  Instead we should use either apply the `file://` scheme  to all our converted links or  strip the default assumed protocol. For now we are going to strip the assumed default protocol.