### PR TITLE
Add figure and figcaption handling

### DIFF
--- a/pymdownx/fig_cap.py
+++ b/pymdownx/fig_cap.py
@@ -44,7 +44,8 @@ class FigureBlockProcessor(BlockProcessor):
         """Test block."""
 
         sibling = self.lastChild(parent)
-        return (self.START.search(block) or (block.startswith(' ' * self.tab_length) and sibling is not None and sibling.tag == 'figure'))
+        return (self.START.search(block) or 
+                (block.startswith(' ' * self.tab_length) and sibling is not None and sibling.tag == 'figure'))
 
     def run(self, parent, blocks):
         """Convert to figure block."""

--- a/pymdownx/fig_cap.py
+++ b/pymdownx/fig_cap.py
@@ -44,7 +44,7 @@ class FigureBlockProcessor(BlockProcessor):
         """Test block."""
 
         sibling = self.lastChild(parent)
-        return (self.START.search(block) or 
+        return (self.START.search(block) or
                 (block.startswith(' ' * self.tab_length) and sibling is not None and sibling.tag == 'figure'))
 
     def run(self, parent, blocks):

--- a/pymdownx/fig_cap.py
+++ b/pymdownx/fig_cap.py
@@ -1,6 +1,5 @@
 """
-Figure and Figcaption Extension
-===============================
+Figure and Figcaption Extension.
 
 This extension adds figure and figcaption handling.
 """
@@ -45,9 +44,7 @@ class FigureBlockProcessor(BlockProcessor):
         """Test block."""
 
         sibling = self.lastChild(parent)
-        return (self.START.search(block)
-                or (block.startswith(' ' * self.tab_length)
-                    and sibling is not None and sibling.tag == 'figure'))
+        return (self.START.search(block) or (block.startswith(' ' * self.tab_length) and sibling is not None and sibling.tag == 'figure'))
 
     def run(self, parent, blocks):
         """Convert to figure block."""
@@ -91,6 +88,7 @@ class FigCapTreeprocessor(Treeprocessor):
     """Get rid of the <p> tag if <img> is the only thing in the <p>."""
 
     def run(self, root):
+        """Operate the <p> that only has a <img> in it and without any text."""
         for figure in root.iterfind('figure'):
             for p in figure.iterfind('p'):
                 if len(p) == 1:

--- a/pymdownx/fig_cap.py
+++ b/pymdownx/fig_cap.py
@@ -1,0 +1,122 @@
+"""
+Figure and Figcaption Extension
+===============================
+
+This extension adds figure and figcaption handling.
+"""
+import re
+from markdown import Extension
+from markdown.blockprocessors import BlockProcessor
+from markdown.treeprocessors import Treeprocessor
+from markdown.util import etree
+
+
+class FigcaptionBlockProcessor(BlockProcessor):
+    """Figcaption block processor."""
+
+    START = re.compile(r'(?:^|\n)%\: {1,3}(.+?) *(?:\n|$)')
+
+    def test(self, parent, block):
+        """Test block."""
+
+        return (parent.tag == 'figure' and self.START.search(block))
+
+    def run(self, parent, blocks):
+        """Convert to figcaption block."""
+
+        block = blocks.pop(0)
+        m = self.START.search(block)
+        div = etree.SubElement(parent, 'figcaption')
+        div.text = m.group(1)
+        block = block[m.end():]
+        if block:
+            div.text = div.text + '\n' + block
+
+
+class FigureBlockProcessor(BlockProcessor):
+    """Figure block processor."""
+
+    COMPRESS_SPACES = re.compile(r' {2,}')
+    START = re.compile(
+        r'''(?:^|\n)(?P<starter>%{3})(?: +(?P<class>[\w\-]+(?: +[\w\-]+)*?))? *(?:\n|$)'''
+    )
+
+    def test(self, parent, block):
+        """Test block."""
+
+        sibling = self.lastChild(parent)
+        return (self.START.search(block)
+                or (block.startswith(' ' * self.tab_length)
+                    and sibling is not None and sibling.tag == 'figure'))
+
+    def run(self, parent, blocks):
+        """Convert to figure block."""
+
+        sibling = self.lastChild(parent)
+        block = blocks.pop(0)
+
+        m = self.START.search(block)
+        if m:
+            # remove the first line
+            block = block[m.end():]
+            if not block:
+                # This is not a figure. Most likely a paragraph that
+                # starts with the figure starter at the beginning
+                # of a document or list.
+                blocks.insert(0, m.group('starter'))
+                return False
+
+        # Get the figure block and and the non-figure content
+        block, non_figure = self.detab(block)
+
+        if m:
+            div = etree.SubElement(parent, 'figure')
+            div_class = '' if m.group(
+                'class') is None else self.COMPRESS_SPACES.sub(
+                    ' ',
+                    m.group('class').lower())
+            if div_class:
+                div.set('class', div_class)
+        else:
+            div = sibling
+
+        self.parser.parseChunk(div, block)
+
+        if non_figure:
+            # Insert the non-figure content back into blocks
+            blocks.insert(0, non_figure)
+
+
+class FigCapTreeprocessor(Treeprocessor):
+    """Get rid of the <p> tag if <img> is the only thing in the <p>."""
+
+    def run(self, root):
+        for figure in root.iterfind('figure'):
+            for p in figure.iterfind('p'):
+                if len(p) == 1:
+                    img = p.find('img')
+                    if img is not None and p.text is None and img.tail == '':
+                        p.attrib = img.attrib
+                        p.tag = img.tag
+                        p.remove(img)
+
+
+class FigCapExtension(Extension):
+    """Add FigCap extension."""
+
+    def extendMarkdown(self, md):
+        """Add FigCap to Markdown instance."""
+
+        md.registerExtension(self)
+        md.parser.blockprocessors.register(
+            FigcaptionBlockProcessor(md.parser), 'figcaption', 95.1)
+        md.parser.blockprocessors.register(
+            FigureBlockProcessor(md.parser), 'figure', 95)
+        # the priority here should lower than the attr_list extension
+        md.treeprocessors.register(FigCapTreeprocessor(md), 'fig_cap', 7)
+
+
+def makeExtension(*args, **kwargs):
+    """Return extension."""
+
+    return FigCapExtension(*args, **kwargs)


### PR DESCRIPTION
Add `<figure>` and `<figcaption>` handling.

- `%%%`  start a `<figure>`
- `%:`  start a `<figcaption>` in `<figure>`

If `<img>` is the only thing in `<p>`, the `<p>` tag will be got rid of.

Example:
```
%%%

%%% figure-class here
    ![img-alt](/source/of/img.jpg){: img-attributes here}

    %: figcaption here
    {: figcaption-attributes here}
```
will be rendered as:

```html
<p>%%%</p>
<figure class="figure-class here">
<img alt="img-alt" here="here" img-attributes="img-attributes" src="/source/of/img.jpg" />
<figcaption figcaption-attributes="figcaption-attributes" here="here">figcaption here</figcaption>
</figure>
```

Starter only will not be rendered as `<figure>`.
The attributes render is supported by the origin [Python-Markdown](https://python-markdown.github.io/)'s  [`attr_list`](https://python-markdown.github.io/extensions/attr_list/) extension.