### PR TITLE
Bring back appveyor

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       max-parallel: 4
       matrix:
-        platform: [ubuntu-latest, windows-latest]
+        platform: [ubuntu-latest]
         python-version: [2.7, 3.5, 3.6, 3.7]
         include:
           - python-version: 2.7
@@ -42,8 +42,9 @@ jobs:
         python -m tox
     - name: Coverage Report
       if: success()
-      run: |
-        python -m codecov -t ${{ secrets.CODECOV_TOKEN }}
+      uses: codecov/codecov-action@v1.0.3
+      with:
+        token: ${{secrets.CODECOV_TOKEN}}
 
   lint:
     strategy:

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       max-parallel: 4
       matrix:
-        platform: [ubuntu-latest, windows-latest]
+        platform: [ubuntu-latest]
         python-version: [2.7, 3.5, 3.6, 3.7]
         include:
           - python-version: 2.7
@@ -39,8 +39,9 @@ jobs:
         python -m tox
     - name: Coverage Report
       if: success()
-      run: |
-        python -m codecov -t ${{ secrets.CODECOV_TOKEN }}
+      uses: codecov/codecov-action@v1.0.3
+      with:
+        token: ${{secrets.CODECOV_TOKEN}}
 
   lint:
     strategy:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,39 @@
+build: false
+
+clone_depth: 5
+
+environment:
+  matrix:
+    - PYTHON: "C:/Python27"
+      TOXENV: "py27"
+    - PYTHON: "C:/Python35"
+      TOXENV: "py35"
+    - PYTHON: "C:/Python36"
+      TOXENV: "py36"
+    - PYTHON: "C:/Python37"
+      TOXENV: "py37"
+    - PYTHON: "C:/Python37"
+      TOXENV: "lint"
+
+init:
+  - "ECHO %TOXENV%"
+  - "ECHO %PYTHON%"
+  - ps: "ls C:/Python*"
+
+install:
+  - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
+  - "python -m pip install --user -U pip"
+  - "python -m pip install -U setuptools wheel"
+  - "python -m pip install -U virtualenv tox codecov"
+
+test_script:
+  - python -m pip --version
+  - virtualenv --version
+  - tox --version
+  - tox
+
+after_test:
+  - if not ("%TOXENV%" == "lint") codecov
+
+matrix:
+  fast_finish: true


### PR DESCRIPTION
GitHub actions can't use secrets when an external source issues a pull,
at least not directly. We can use the codecov action to work around
this, but it doesn't work in Windows.