### PR TITLE
GitHub CI and Python coverage just don't go together

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,46 +6,6 @@ on:
       - 'master'
 
 jobs:
-  tests:
-    strategy:
-      fail-fast: false
-      max-parallel: 4
-      matrix:
-        platform: [ubuntu-latest]
-        python-version: [2.7, 3.5, 3.6, 3.7]
-        include:
-          - python-version: 2.7
-            tox-env: py27
-          - python-version: 3.5
-            tox-env: py35
-          - python-version: 3.6
-            tox-env: py36
-          - python-version: 3.7
-            tox-env: py37
-
-    env:
-      TOXENV: ${{ matrix.tox-env }}
-
-    runs-on: ${{ matrix.platform }}
-
-    steps:
-    - uses: actions/checkout@v1
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip setuptools tox coverage codecov
-    - name: Test with pytest
-      run: |
-        python -m tox
-    - name: Coverage Report
-      if: success()
-      uses: codecov/codecov-action@v1.0.3
-      with:
-        token: ${{secrets.CODECOV_TOKEN}}
-
   lint:
     strategy:
       max-parallel: 4

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -3,46 +3,6 @@ name: pull request
 on: [pull_request]
 
 jobs:
-  tests:
-    strategy:
-      fail-fast: false
-      max-parallel: 4
-      matrix:
-        platform: [ubuntu-latest]
-        python-version: [2.7, 3.5, 3.6, 3.7]
-        include:
-          - python-version: 2.7
-            tox-env: py27
-          - python-version: 3.5
-            tox-env: py35
-          - python-version: 3.6
-            tox-env: py36
-          - python-version: 3.7
-            tox-env: py37
-
-    env:
-      TOXENV: ${{ matrix.tox-env }}
-
-    runs-on: ${{ matrix.platform }}
-
-    steps:
-    - uses: actions/checkout@v1
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip setuptools tox coverage codecov
-    - name: Test with pytest
-      run: |
-        python -m tox
-    - name: Coverage Report
-      if: success()
-      uses: codecov/codecov-action@v1.0.3
-      with:
-        token: ${{secrets.CODECOV_TOKEN}}
-
   lint:
     strategy:
       max-parallel: 4

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,14 +6,16 @@ sudo: true
 git:
   depth: 5
 
-# Cache dependencies
-cache:
-  yarn: true
-  directories:
-    - node_modules
-
 matrix:
   include:
+    - python: 2.7
+      env: TOXENV=py27
+    - python: 3.5
+      env: TOXENV=py35
+    - python: 3.6
+      env: TOXENV=py36
+    - python: 3.7
+      env: TOXENV=py37
     - python: 3.8-dev
       env: TOXENV=py38
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,8 +12,6 @@ environment:
       TOXENV: "py36"
     - PYTHON: "C:/Python37"
       TOXENV: "py37"
-    - PYTHON: "C:/Python37"
-      TOXENV: "lint"
 
 init:
   - "ECHO %TOXENV%"
@@ -33,7 +31,7 @@ test_script:
   - tox
 
 after_test:
-  - if not ("%TOXENV%" == "lint") codecov
+  - codecov
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
I accept defeat. Keep tests on Travis and Appveyor.

This was a big waste of time. GitHub CI adds a lot of cool things, and I plan on still using it for some things, but unittests with coverage is not one of them until either of the coverage options can get something working in actions that also works with external pull requests.