### PR TITLE
Fix issue: generated absolute paths in Windows don't work in Firefox

### DIFF
--- a/docs/src/markdown/changelog.md
+++ b/docs/src/markdown/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 6.2.1
+
+- **FIX**: Fix issue in PathConverter where Windows path conversion from relative to absolute doesn't always work in all
+  browsers.
+
 ## 6.2.0
 
 - **NEW**: Upgrade Twemoji to use 12.1.3.

--- a/pymdownx/pathconverter.py
+++ b/pymdownx/pathconverter.py
@@ -80,7 +80,10 @@ def repl_relative(m, base_path, relative_path):
                 )
                 # Convert the path, URL encode it, and format it as a link
                 path = util.path2url(path)
-                link = '%s"%s"' % (m.group('name'), util.urlunparse((scheme, netloc, path, params, query, fragment)))
+                link = '%s"%s"' % (
+                    m.group('name'),
+                    util.urlunparse((scheme, netloc, path, params, query, fragment))
+                )
     except Exception:  # pragma: no cover
         # Parsing crashed and burned; no need to continue.
         pass
@@ -99,7 +102,12 @@ def repl_absolute(m, base_path):
             path = util.url2path(path)
             path = os.path.normpath(os.path.join(base_path, path))
             path = util.path2url(path)
-            link = '%s"%s"' % (m.group('name'), util.urlunparse((scheme, netloc, path, params, query, fragment)))
+            start = '/' if not path.startswith('/') else ''
+            link = '%s"%s%s"' % (
+                m.group('name'),
+                start,
+                util.urlunparse((scheme, netloc, path, params, query, fragment))
+            )
     except Exception:  # pragma: no cover
         # Parsing crashed and burned; no need to continue.
         pass

--- a/tests/test_extensions/test_pathconverter.py
+++ b/tests/test_extensions/test_pathconverter.py
@@ -258,12 +258,12 @@ class TestWindowsAbs(util.MdCase):
         if util.is_win():
             self.check_markdown(
                 r'![picture](./extensions/_assets/bg.png)',
-                r'<p><img alt="picture" src="C:/Some/fake/path/extensions/_assets/bg.png" /></p>'
+                r'<p><img alt="picture" src="/C:/Some/fake/path/extensions/_assets/bg.png" /></p>'
             )
         else:
             self.check_markdown(
                 r'![picture](./extensions/_assets/bg.png)',
-                r'<p><img alt="picture" src="C%3A/Some/fake/path/extensions/_assets/bg.png" /></p>'
+                r'<p><img alt="picture" src="/C%3A/Some/fake/path/extensions/_assets/bg.png" /></p>'
             )
 
 


### PR DESCRIPTION
Only chrome allows URLs in the form c:/path/image.png etc. Others
require at least /c:/path/image.png.

https://github.com/facelessuser/MarkdownPreview/issues/100