### PR TITLE
SuperFences/Highlight updates

### DIFF
--- a/docs/src/dictionary/en-custom.txt
+++ b/docs/src/dictionary/en-custom.txt
@@ -140,6 +140,7 @@ highlighter's
 hostnames
 html
 indepth
+injectable
 inline
 ish
 isn't

--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -7,10 +7,6 @@ Please see [Release Notes](./release.md#upgrading-to-70) for details on upgradin
 - **NEW**: SuperFences, if using the attribute list format (` ``` {.lang .additional_class, linenums="1"} `) allows
   adding additional classes. IDs can be added as well, though Pygments generated code blocks do not have a mechanism to
   actually insert IDs. The first provided class will always be treated as the language class.
-- **NEW**: In non-Pygments generated code blocks, the special `highlight` class (or whatever the user specifies) is now
-  generated on the `!#html <code>` element along with any extra classes and the language class. Pygments code blocks and
-  built in custom code blocks remain unchanged. This change was made to consolidate where the new attribute list's added
-  classes should go. This consistently includes all classes in the same place to avoid confusion.
 - **NEW**: Custom SuperFences' formatters should now also include the keyword parameters`classes` and `id_value` to
   allow injecting classes and IDs via the now supported attribute list format. If a code block defines no additional IDs
   and classes, the old form will be used. Formatters should include `**kwargs` at the end to future proof them from

--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -1,14 +1,33 @@
 # Changelog
 
+## 7.0b2
+
+Please see [Release Notes](./release.md#upgrading-to-70) for details on upgrading to 7.0.
+
+- **NEW**: SuperFences, if using the attribute list format (` ``` {.lang .additional_class, linenums="1"} `) allows
+  adding additional classes. IDs can be added as well, though Pygments generated code blocks do not have a mechanism to
+  actually insert IDs. The first provided class will always be treated as the language class.
+- **NEW**: In non-Pygments generated code blocks, the special `highlight` class (or whatever the user specifies) is now
+  generated on the `!#html <code>` element along with any extra classes and the language class. Pygments code blocks and
+  built in custom code blocks remain unchanged. This change was made to consolidate where the new attribute list's added
+  classes should go. This consistently includes all classes in the same place to avoid confusion.
+- **NEW**: Custom SuperFences' formatters should now also include the keyword parameters`classes` and `id_value` to
+  allow injecting classes and IDs via the now supported attribute list format. If a code block defines no additional IDs
+  and classes, the old form will be used. Formatters should include `**kwargs` at the end to future proof them from
+  future changes.
+- **NEW**: Deprecate the SuperFences `highight_code` option. As SuperFences syntax has language classes built right in,
+  disabling the `highlight_code` option makes little sense. While `highlight_code` is still accepted, it currently does
+  nothing and will be removed at some future time.
+
 ## 7.0b1
 
-Please see [Release Notes](./release.md) for details on upgrading to 7.0.0.
+Please see [Release Notes](./release.md#upgrading-to-70) for details on upgrading to 7.0.
 
 - **NEW**: Add new Tabbed extension for general purpose tabbed content in Markdown.
-- **NEW**: Deprecate old SuperFences tabbed content feature. This will be removed in 8.0.0.
+- **NEW**: Deprecate old SuperFences tabbed content feature. This will be removed in 8.0.
 - **NEW**: SuperFences' tabbed content classes have changed from `supferfences-tabs` and `superfences-content` to
   `tabbed-set` and `tabbed-content` respectively. Old style classes can be enabled with the `legacy_tab_classes` option
-  in SuperFences. This new option will be retired with SuperFences tabbed content feature in 8.0.0.
+  in SuperFences. This new option will be retired with SuperFences tabbed content feature in 8.0.
 - **FIX**: Numerous deprecation warnings associated with the recent release of Python Markdown 3.2.
 
 ## 6.3

--- a/docs/src/markdown/about/release.md
+++ b/docs/src/markdown/about/release.md
@@ -1,7 +1,8 @@
 # Release Notes
 
-## Upgrading to 7.0b1
+## Upgrading to 7.0
 
+### Tabbed Extension
 A new extension called Tabbed has been added. With the arrival of this general purpose tabbed content extension, it has
 made the old SuperFences tabbed content feature redundant. By default, SuperFences will now change the classes it uses
 for it's tabbed feature to match those of the new Tabbed extension. CSS should be updated accordingly.
@@ -23,11 +24,41 @@ extension_configs = {
 
 To learn more about migrating to the Tabbed extension, checkout the [Tabbed documentation](../extensions/tabbed.md).
 
-SuperFences' tab content feature will be removed in 8.0.0. There is no formal date for when this will occur, but it is
+SuperFences' tab content feature will be removed in 8.0. There is no formal date for when this will occur, but it is
 recommended to begin migrating as soon as possible, but `legacy_tab_classes` can be used as a stop gap for the short
 term.
 
-## Upgrading to 6.0.0
+### Option Deprecation in SuperFences
+
+SuperFences has deprecated `highlight_code`. This option now does nothing and will be removed in some future release.
+If this option was used, you will have to use [custom fences](../extensions/superfences.md#custom-fences) to implement
+this behavior with your own custom formatter.
+
+### SuperFences Attribute List Style
+
+Additional classes and IDs can now be injected into fenced code blocks with the format ` ```{.lang .more-class} `.
+
+1. When Pygments was disabled for traditional code blocks, the output for JavaScript syntax highlighters had the
+  generalized highlight class attached to the `#!html <pre>` element and the language class was attached to the
+  `#!html <code>` element. With the ability to add multiple classes, classes are now all attached to the `#!html <code>`
+  element for consistency.
+
+2. The attribute list feature also impacts the the custom formatter. While the default formatters will still inject
+  classes and IDs to the top level element to preserve backwards compatibility, the formatter now must accept the new
+  keyword parameters `classes` and `id_value`. If you have a custom formatter that does not adhere to this new
+  requirement, you will see a user warning.
+
+    The new format is:
+
+    ```py3
+    def custom_formatter(source, language, css_class, options, md, classes=None, id_value='', **kwargs):
+        return string
+    ```
+
+    While it is recommended for a user to update their custom formatters to receive the new parameters, at the very
+    least, users should add `**kwargs` to future proof their formatters.
+
+## Upgrading to 6.0
 
 While there are a number of new features and bug fixes, the only backwards incompatible changes are with SuperFences'
 custom fences. In an effort to make custom fences more useful, we wanted to be able to pass the `Markdown` object to the

--- a/docs/src/markdown/about/release.md
+++ b/docs/src/markdown/about/release.md
@@ -38,38 +38,20 @@ this behavior with your own custom formatter.
 
 Additional classes and IDs can now be injected into fenced code blocks with the format ` ```{.lang .more-class} `.
 
-1. When Pygments was disabled for traditional code blocks, the output for JavaScript syntax highlighters had the
-  generalized highlight class attached to the `#!html <pre>` element and the language class was attached to the
-  `#!html <code>` element. With the ability to add multiple classes, classes are now all attached to the `#!html <code>`
-  element for consistency.
+The attribute list feature also impacts the the custom formatter. While the default formatters will still inject
+classes and IDs to the top level element to preserve backwards compatibility, the formatter now must accept the new
+keyword parameters `classes` and `id_value`. If you have a custom formatter that does not adhere to this new
+requirement, you will see a user warning.
 
-2. The attribute list feature also impacts the the custom formatter. While the default formatters will still inject
-  classes and IDs to the top level element to preserve backwards compatibility, the formatter now must accept the new
-  keyword parameters `classes` and `id_value`. If you have a custom formatter that does not adhere to this new
-  requirement, you will see a user warning.
+The new format is:
 
-    The new format is:
+```py3
+def custom_formatter(source, language, css_class, options, md, classes=None, id_value='', **kwargs):
+    return string
+```
 
-    ```py3
-    def custom_formatter(source, language, css_class, options, md, classes=None, id_value='', **kwargs):
-        return string
-    ```
-
-    While it is recommended for a user to update their custom formatters to receive the new parameters, at the very
-    least, users should add `**kwargs` to future proof their formatters.
-
-### Line Numbers and Non-Pygments Code Blocks
-
-In the past, SuperFences has injected the `linenums` class into code blocks when Pygments is turned off. The idea was
-maybe it could be used to help to specify that line numbers were wanted, and a JavaScript highlighter could use it in
-some way. Moving forward, non Pygments code blocks will not inject the `linenums` class if the `linenums` option is
-provided in a fenced code block header.
-
-The truth is that JavaScript Highlighters all have their own specific syntaxes to handle line numbers, and simply
-providing `linenums` isn't really that helpful. If it is, a user can now use the attribute list style and inject
-whatever class they find helpful to generate line numbers with their preferred JavaScript highlighter. Additionally,
-a user could use custom fences to more directly serve up exactly the format they prefer and even specify line numbers
-ranges etc.
+While it is recommended for a user to update their custom formatters to receive the new parameters, at the very
+least, users should add `**kwargs` to future proof their formatters.
 
 ## Upgrading to 6.0
 

--- a/docs/src/markdown/about/release.md
+++ b/docs/src/markdown/about/release.md
@@ -34,7 +34,7 @@ SuperFences has deprecated `highlight_code`. This option now does nothing and wi
 If this option was used, you will have to use [custom fences](../extensions/superfences.md#custom-fences) to implement
 this behavior with your own custom formatter.
 
-### SuperFences Attribute List Style
+### SuperFences' Attribute List Style
 
 Additional classes and IDs can now be injected into fenced code blocks with the format ` ```{.lang .more-class} `.
 
@@ -57,6 +57,19 @@ Additional classes and IDs can now be injected into fenced code blocks with the 
 
     While it is recommended for a user to update their custom formatters to receive the new parameters, at the very
     least, users should add `**kwargs` to future proof their formatters.
+
+### Line Numbers and Non-Pygments Code Blocks
+
+In the past, SuperFences has injected the `linenums` class into code blocks when Pygments is turned off. The idea was
+maybe it could be used to help to specify that line numbers were wanted, and a JavaScript highlighter could use it in
+some way. Moving forward, non Pygments code blocks will not inject the `linenums` class if the `linenums` option is
+provided in a fenced code block header.
+
+The truth is that JavaScript Highlighters all have their own specific syntaxes to handle line numbers, and simply
+providing `linenums` isn't really that helpful. If it is, a user can now use the attribute list style and inject
+whatever class they find helpful to generate line numbers with their preferred JavaScript highlighter. Additionally,
+a user could use custom fences to more directly serve up exactly the format they prefer and even specify line numbers
+ranges etc.
 
 ## Upgrading to 6.0
 

--- a/docs/src/markdown/extensions/highlight.md
+++ b/docs/src/markdown/extensions/highlight.md
@@ -103,6 +103,6 @@ Option                    | Type   | Default               | Description
 `legacy_no_wrap_code`     | bool   | `#!py3 False`         | A temporary option provided during the transition period to the new output format. From now on, all block code under `pre` elements will be wrapped in a `code` element as well under Pygments 2.4+. This disables this format. This option will be removed in the future.
 
 !!! new "New Option 6.2"
-    `legacy_no_wrap_code` was added in `6.2`, but is only provided to help transition to the format when using Pygments 2.4+. This option will be removed in the future.
+    `legacy_no_wrap_code` was added in `6.3`, but is only provided to help transition to the format when using Pygments 2.4+. This option will be removed in the future.
 
 --8<-- "refs.txt"

--- a/docs/src/markdown/extensions/superfences.md
+++ b/docs/src/markdown/extensions/superfences.md
@@ -103,10 +103,8 @@ be inserted as those are reserved for options such has `linenums` etc.
         <table class="extra-class highlighttable"><tr><td class="linenos"><div class="linenodiv"><pre><span></span>1</pre></div></td><td class="code"><div class="extra-class highlight"><pre><span></span><code><span cv></td><td class="code"><div class="extra-class highlight"><pre><span></span><code><span class="kn">import</span> <spanlass="kn">import</span> <span class="nn">hello_world</span>\n</code></pre></div>\n</td></tr></table>
         ```
 
-Previously, before this feature, the general `highlight` class was injected on the `#!html <pre>` element, while the
-language element was injected into the `#!html <code>` element. To avoid confusion as we can now inject multiple
-classes, we now group all classes into the `#!html <code>` element in non-Pygments, non-custom formatted code blocks.
-IDs in this scenario are inserted into the `#!html <pre>`.
+When generating additional classes on a JavaScript style code block (non-Pygments code blocks), classes are injected in
+the `#!html code` block.
 
 !!! example "Non-Pygments Injecting Classes"
      === "Source"
@@ -118,7 +116,7 @@ IDs in this scenario are inserted into the `#!html <pre>`.
 
     === "HTML"
         ```html
-        <pre id="id"><code class="extra-class highlight language-python linenums">import hello_world</code></pre>
+        <pre id="id" class="highlight"><code class="extra-class language-python linenums">import hello_world</code></pre>
         ```
 
 When using a built in [custom formatter](#custom-fences), all classes and IDs are injected on to the first element
@@ -408,8 +406,9 @@ Special must be a value of n > 0.
         import foo.bar.baz
         ```
 
-For JavaScript libraries, nothing is injected into the output. Since every JavaScript library has different requirements
-to get line numbers to show, it is impossible for SuperFences to know what to inject.
+For JavaScript libraries, a class of `linenums` is written to the block.  This may or may not be leveraged by your
+chosen highlighter.  It is uncertain at this time whether line number support for JavaScript highlighters will be
+enhanced beyond this.w what to inject.
 
 ## Highlighting Lines
 

--- a/docs/src/markdown/extensions/superfences.md
+++ b/docs/src/markdown/extensions/superfences.md
@@ -408,9 +408,8 @@ Special must be a value of n > 0.
         import foo.bar.baz
         ```
 
-For JavaScript libraries, a class of `linenums` is written to the block.  This may or may not be leveraged by your
-chosen highlighter.  It is uncertain at this time whether line number support for JavaScript highlighters will be
-enhanced beyond this.
+For JavaScript libraries, nothing is injected into the output. Since every JavaScript library has different requirements
+to get line numbers to show, it is impossible for SuperFences to know what to inject.
 
 ## Highlighting Lines
 

--- a/docs/src/markdown/extensions/superfences.md
+++ b/docs/src/markdown/extensions/superfences.md
@@ -84,6 +84,47 @@ md = markdown.Markdown(extensions=['pymdownx.superfences'])
     Another paragraph.
     ````
 
+## Injecting Classes and IDs
+
+You can use the attribute list format to specify classes and IDs (IDs are only injectable in non-Pygments code blocks).
+The first provided class is always used as the language class. Arbitrary attributes in the form `key="value"` cannot
+be inserted as those are reserved for options such has `linenums` etc.
+
+!!! example "Injecting Classes"
+    === "Source"
+        ````
+        ```{.python .extra-class linenums="1"}
+        import hello_world
+        ```
+        ````
+
+    === "HTML"
+        ```html
+        <table class="extra-class highlighttable"><tr><td class="linenos"><div class="linenodiv"><pre><span></span>1</pre></div></td><td class="code"><div class="extra-class highlight"><pre><span></span><code><span cv></td><td class="code"><div class="extra-class highlight"><pre><span></span><code><span class="kn">import</span> <spanlass="kn">import</span> <span class="nn">hello_world</span>\n</code></pre></div>\n</td></tr></table>
+        ```
+
+Previously, before this feature, the general `highlight` class was injected on the `#!html <pre>` element, while the
+language element was injected into the `#!html <code>` element. To avoid confusion as we can now inject multiple
+classes, we now group all classes into the `#!html <code>` element in non-Pygments, non-custom formatted code blocks.
+IDs in this scenario are inserted into the `#!html <pre>`.
+
+!!! example "Non-Pygments Injecting Classes"
+     === "Source"
+        ````
+        ```{.python .extra-class #id linenums="1"}
+        import hello_world
+        ```
+        ````
+
+    === "HTML"
+        ```html
+        <pre id="id"><code class="extra-class highlight language-python linenums">import hello_world</code></pre>
+        ```
+
+When using a built in [custom formatter](#custom-fences), all classes and IDs are injected on to the first element
+`#!html <div>` or `#!html <pre>`. This preserves previous behavior, but you can write your own and inject them in the
+way that suites your needs.
+
 ## Tabbed Fences
 
 !!! warning "Deprecated 7.0b1"
@@ -508,9 +549,16 @@ originally defined via the `class` option in the `custom_fence` entry, custom op
 you want access to meta data etc.).
 
 ```py3
-def custom_formatter(source, language, css_class, options, md):
+def custom_formatter(source, language, css_class, options, md, classes=None, id_value='', **kwargs):
     return string
 ```
+
+!!! new "New 7.0b2"
+    The addition of the parameters `classes` and `id_value` is new in 7.0b2. If injecting additional classes or ids via
+    the [attribute list style](#injecting-classes-and-ids), only then will `classes` and `id_value` be passed in to
+    preserve backwards compatibility with old custom formatters. Users, moving forward, should at the very least update
+    their formatters with `**kwargs` to future proof their custom formatters in case additional parameters are added
+    in the future.
 
 All formatters should return a string as HTML.
 
@@ -798,6 +846,9 @@ Option                         | Type         | Default       | Description
     only provided as an option to help with the transition of the code tab feature being deprecated in favor of the
     [Tabbed](./tabbed.md) extension. When the code tabs are removed from SuperFences, so will
     `legacy_tab_classes`.
+
+    `highlight_code` is also disabled and now does nothing. If a non-highlighted variant of fences is preferred, it is
+    recommend to use [custom fences](#custom-fences). This option will be removed in a future version.
 
 --8<-- "links.txt"
 

--- a/pymdownx/__meta__.py
+++ b/pymdownx/__meta__.py
@@ -186,5 +186,5 @@ def parse_version(ver, pre=False):
     return Version(major, minor, micro, release, pre, post, dev)
 
 
-__version_info__ = Version(7, 0, 0, "beta", 1)
+__version_info__ = Version(7, 0, 0, "beta", 2)
 __version__ = __version_info__._get_canonical()

--- a/pymdownx/arithmatex.py
+++ b/pymdownx/arithmatex.py
@@ -130,19 +130,21 @@ def inline_generic_format(math, language='math', class_name='arithmatex', md=Non
 
 
 # Formatters usable with SuperFences
-def fence_mathjax_preview_format(math, language='math', class_name='arithmatex', options=None, md=None):
+def fence_mathjax_preview_format(math, language='math', class_name='arithmatex', options=None, md=None, **kwargs):
     """Block MathJax formatter with preview."""
 
     return _fence_mathjax_format(math, True)
 
 
-def fence_mathjax_format(math, language='math', class_name='arithmatex', options=None, md=None):
+def fence_mathjax_format(math, language='math', class_name='arithmatex', options=None, md=None, **kwargs):
     """Block MathJax formatter."""
 
     return _fence_mathjax_format(math, False)
 
 
-def fence_generic_format(math, language='math', class_name='arithmatex', options=None, md=None, wrap='\\[\n%s\n\\]'):
+def fence_generic_format(
+    math, language='math', class_name='arithmatex', options=None, md=None, wrap='\\[\n%s\n\\]', **kwargs
+):
     """Generic block formatter."""
 
     return '<div class="%s">%s</div>' % (class_name, (wrap % math))

--- a/pymdownx/highlight.py
+++ b/pymdownx/highlight.py
@@ -260,15 +260,17 @@ class Highlight(object):
         if pygments and self.use_pygments:
             # Setup language lexer.
             lexer = self.get_lexer(src, language)
+            linenums = self.linenums_style if (self.linenums or linestart >= 0) and not inline > 0 else False
 
             if class_names:
                 css_class = ' {}'.format('' if not css_class else css_class)
                 css_class = ' '.join(class_names) + css_class
-                if not css_class.strip():
-                    css_class = ''
+                stripped = css_class.strip()
+
+                if not isinstance(linenums, str) or linenums != 'table':
+                    css_class = stripped
 
             # Setup line specific settings.
-            linenums = self.linenums_style if (self.linenums or linestart >= 0) and not inline > 0 else False
             if not linenums or linestep < 1:
                 linestep = 1
             if not linenums or linestart < 1:

--- a/pymdownx/highlight.py
+++ b/pymdownx/highlight.py
@@ -44,6 +44,7 @@ except Exception:  # pragma: no cover
 
 CODE_WRAP = '<pre%s><code%s>%s</code></pre>'
 CLASS_ATTR = ' class="%s"'
+ID_ATTR = ' id="%s"'
 DEFAULT_CONFIG = {
     'use_pygments': [
         True,
@@ -249,7 +250,7 @@ class Highlight(object):
 
     def highlight(
         self, src, language, css_class='highlight', hl_lines=None,
-        linestart=-1, linestep=-1, linespecial=-1, inline=False
+        linestart=-1, linestep=-1, linespecial=-1, inline=False, id_value=''
     ):
         """Highlight code."""
 
@@ -300,17 +301,15 @@ class Highlight(object):
                 class_str = ' '.join(classes)
         else:
             # Format block code for a JavaScript Syntax Highlighter by specifying language.
-            classes = []
-            linenums = self.linenums_style if (self.linenums or linestart >= 0) and not inline > 0 else False
+            classes = [css_class] if css_class else []
             if language:
                 classes.append('language-%s' % language)
-            if linenums:
-                classes.append('linenums')
             class_str = ''
             if classes:
                 class_str = CLASS_ATTR % ' '.join(classes)
-            higlight_class = (CLASS_ATTR % css_class) if css_class else ''
-            code = CODE_WRAP % (higlight_class, class_str, self.escape(src))
+            if id_value:
+                id_value = ID_ATTR % id_value
+            code = CODE_WRAP % (id_value, class_str, self.escape(src))
 
         if inline:
             el = etree.Element('code', {'class': class_str} if class_str else {})

--- a/pymdownx/superfences.py
+++ b/pymdownx/superfences.py
@@ -35,7 +35,8 @@ from markdown.preprocessors import Preprocessor
 from markdown.postprocessors import Postprocessor
 from markdown.blockprocessors import CodeBlockProcessor
 from markdown import util as md_util
-from . import util
+from .util import PymdownxDeprecationWarning
+import warnings
 import functools
 import re
 
@@ -47,16 +48,27 @@ PREFIX_CHARS = ('>', ' ', '\t')
 RE_NESTED_FENCE_START = re.compile(
     r'''(?x)
     (?P<fence>~{3,}|`{3,})[ \t]*                                                   # Fence opening
-    (\{?                                                                           # Language opening
-    \.?(?P<lang>[\w#.+-]*))?[ \t]*                                                 # Language
-    (?P<options>(?:\b[a-zA-Z][a-zA-Z0-9_]*=(?:(?P<quot>"|').*?(?P=quot))?[ \t]*)*) # Options
-    }?[ \t]*$                                                                      # Language closing
+    (?:(?:(?P<bracket_open>\{)|\.?(?P<lang>[\w#.+-]*))?)[ \t]*                     # Language opening
+    (?P<options>
+        (?:
+            (?:\b[a-zA-Z][a-zA-Z0-9_]*=(?:(?P<quot>"|').*?(?P=quot))?[ \t]*) |     # Options
+            (?:(?<=[{ \t])[.\#][\w#.+-]+[ \t]*)                                    # Class or ID
+        )*
+    )
+    (?P<bracket_close>})?[ \t]*$                                                   # Language closing
     '''
 )
 
 RE_HL_LINES = re.compile(r'(?P<hl_lines>\d+(?:[ \t]+\d+)*)')
 RE_LINENUMS = re.compile(r'(?P<linestart>[\d]+)(?:[ \t]+(?P<linestep>[\d]+))?(?:[ \t]+(?P<linespecial>[\d]+))?')
-RE_OPTIONS = re.compile(r'''(?P<key>[a-zA-Z][a-zA-Z0-9_]*)=(?:(?P<quot>"|')(?P<value>.*?)(?P=quot))?''')
+RE_OPTIONS = re.compile(
+    r'''(?x)
+    (?:
+        (?P<key>[a-zA-Z][a-zA-Z0-9_]*)=(?:(?P<quot>"|')(?P<value>.*?)(?P=quot))? |
+        (?P<class_id>(?:(?<=[ \t])|(?<=^))[.\#][\w#.+-]+)
+    )
+    '''
+)
 
 RE_TAB_DIV = re.compile(
     r'<div (?:class="tabbed-set" data-tabs="(\d+:\d+)"|data-tabs="(\d+:\d+)" class="tabbed-set")'
@@ -138,16 +150,24 @@ class CodeStash(object):
         self.stash = {}
 
 
-def fence_code_format(source, language, css_class, options, md):
+def fence_code_format(source, language, css_class, options, md, classes=None, id_value='', **kwargs):
     """Format source as code blocks."""
 
-    return '<pre class="%s"><code>%s</code></pre>' % (css_class, _escape(source))
+    if id_value:
+        id_value = ' id="{}"'.format(id_value)
+    classes = css_class if classes is None else ' '.join(classes + [css_class])
+
+    return '<pre%s class="%s"><code>%s</code></pre>' % (id_value, classes, _escape(source))
 
 
-def fence_div_format(source, language, css_class, options, md):
+def fence_div_format(source, language, css_class, options, md, classes=None, id_value='', **kwargs):
     """Format source as div."""
 
-    return '<div class="%s">%s</div>' % (css_class, _escape(source))
+    if id_value:
+        id_value = ' id="{}"'.format(id_value)
+    classes = css_class if classes is None else ' '.join(classes + [css_class])
+
+    return '<div%s class="%s">%s</div>' % (id_value, classes, _escape(source))
 
 
 def highlight_validator(language, options):
@@ -184,10 +204,10 @@ def _validator(language, options, validator=None):
     return validator(language, options)
 
 
-def _formatter(source, language, options, md, class_name="", fmt=None):
+def _formatter(source, language, options, md, class_name="", _fmt=None, **kwargs):
     """Formatter wrapper."""
 
-    return fmt(source, language, class_name, options, md)
+    return _fmt(source, language, class_name, options, md, **kwargs)
 
 
 def _test(language, test_language=None):
@@ -206,7 +226,7 @@ class SuperFencesCodeExtension(Extension):
         self.config = {
             'disable_indented_code_blocks': [False, "Disable indented code blocks - Default: False"],
             'custom_fences': [[], 'Specify custom fences. Default: See documentation.'],
-            'highlight_code': [True, "Highlight code - Default: True"],
+            'highlight_code': [True, "Deprecated and does nothing"],
             'css_class': [
                 '',
                 "Set class name for wrapper element. The default of CodeHilite or Highlight will be used"
@@ -261,7 +281,7 @@ class SuperFencesCodeExtension(Extension):
             if name is not None and class_name is not None:
                 self.extend_super_fences(
                     name,
-                    functools.partial(_formatter, class_name=class_name, fmt=fence_format),
+                    functools.partial(_formatter, class_name=class_name, _fmt=fence_format),
                     functools.partial(_validator, validator=validator)
                 )
 
@@ -390,7 +410,11 @@ class SuperFencesBlockPreprocessor(Preprocessor):
 
         if not self.checked_hl_settings:
             self.checked_hl_settings = True
-            self.highlight_code = self.config['highlight_code']
+            if not self.config['highlight_code']:
+                warnings.warn(
+                    "Disabling of 'highlight_code' is deprecated and no longer does anything.",
+                    PymdownxDeprecationWarning
+                )
 
             config = None
             self.highlighter = None
@@ -429,6 +453,8 @@ class SuperFencesBlockPreprocessor(Preprocessor):
         self.fence_end = None
         self.tab = None
         self.options = {}
+        self.classes = []
+        self.id = ''
 
     def eval_fence(self, ws, content, start, end):
         """Evaluate a normal fence."""
@@ -490,7 +516,23 @@ class SuperFencesBlockPreprocessor(Preprocessor):
         code = None
         for entry in reversed(self.extension.superfences):
             if entry["test"](self.lang):
-                code = entry["formatter"](self.rebuild_block(self.code), self.lang, self.options, self.md)
+
+                try:
+                    code = entry["formatter"](
+                        self.rebuild_block(self.code),
+                        self.lang,
+                        self.options,
+                        self.md,
+                        classes=self.classes,
+                        id_value=self.id
+                    )
+                except TypeError:  # pragma: no cover
+                    code = entry["formatter"](self.rebuild_block(self.code), self.lang, self.options, self.md)
+                    warnings.warn(
+                        "Custom fence Formatters are required to accept keyword parameters 'classes' and 'id_value'",
+                        UserWarning
+                    )
+
                 if self.tab is not None:
                     code = self.get_tab(code, self.tab)
                 break
@@ -563,22 +605,31 @@ class SuperFencesBlockPreprocessor(Preprocessor):
 
         return ws
 
-    def parse_options(self, string):
+    def parse_options(self, string, allow_class_id=False):
         """Get options."""
 
         okay = True
 
         self.options = {}
         for m in RE_OPTIONS.finditer(string):
-            key = m.group('key')
-            value = m.group('value')
-            if value is None:
-                value = True
-            self.options[key] = value
+            if m.group('class_id'):
+                if not allow_class_id:
+                    return False
+                item = m.group('class_id')
+                if item.startswith('.'):
+                    self.classes.append(item[1:])
+                else:
+                    self.id = item[1:]
+            else:
+                key = m.group('key')
+                value = m.group('value')
+                if value is None:
+                    value = True
+                self.options[key] = value
 
         # Global options (remove as we handle them)
         if 'tab' in self.options:
-            util.PymdownxDeprecationWarning(MSG_TAB_DEPRECATION)
+            warnings.warn(MSG_TAB_DEPRECATION, PymdownxDeprecationWarning)
             self.tab = self.options['tab']
             if not self.tab or self.tab is True:
                 self.tab = self.lang
@@ -610,18 +661,29 @@ class SuperFencesBlockPreprocessor(Preprocessor):
                 # Found the start of a fenced block.
                 m = RE_NESTED_FENCE_START.match(line, self.ws_len)
                 if m is not None:
-                    start = count
-                    self.first = ws + self.normalize_ws(m.group(0))
-                    self.ws = ws
-                    self.quote_level = self.ws.count(">")
-                    self.empty_lines = 0
-                    self.fence = m.group('fence')
-                    self.lang = m.group('lang')
-                    if self.parse_options(m.group('options')):
-                        self.fence_end = re.compile(NESTED_FENCE_END % self.fence)
-                    else:
-                        # Option parsing failed, abandon fence
+                    if (
+                        (m.group('bracket_open') and not m.group('bracket_close')) or
+                        (not m.group('bracket_open') and m.group('bracket_close'))
+                    ):
                         self.clear()
+
+                    else:
+                        start = count
+                        is_attr_list = m.group('bracket_open')
+                        self.first = ws + self.normalize_ws(m.group(0))
+                        self.ws = ws
+                        self.quote_level = self.ws.count(">")
+                        self.empty_lines = 0
+                        self.fence = m.group('fence')
+                        if not is_attr_list:
+                            self.lang = m.group('lang')
+                        if self.parse_options(m.group('options'), is_attr_list):
+                            if is_attr_list:
+                                self.lang = self.classes.pop(0) if self.classes else ''
+                            self.fence_end = re.compile(NESTED_FENCE_END % self.fence)
+                        else:
+                            # Option parsing failed, abandon fence
+                            self.clear()
             else:
                 # Evaluate lines
                 # - Determine if it is the ending line or content line
@@ -662,7 +724,7 @@ class SuperFencesBlockPreprocessor(Preprocessor):
             lines = lines[:start] + [fenced] + lines[end:]
         return lines
 
-    def highlight(self, src, language, options, md):
+    def highlight(self, src, language, options, md, classes=None, id_value='', **kwargs):
         """
         Syntax highlight the code block.
 
@@ -670,11 +732,17 @@ class SuperFencesBlockPreprocessor(Preprocessor):
         is enabled, so we call into it to highlight the code.
         """
 
+        if classes is None:  # pragma: no cover
+            classes = []
+        classes.append(self.css_class)
+        classes = ' '.join(classes)
+
         # Default format options
         linestep = None
         linestart = None
         linespecial = None
         hl_lines = None
+
         if 'hl_lines' in options:
             m = RE_HL_LINES.match(options['hl_lines'])
             hl_lines = m.group('hl_lines')
@@ -684,34 +752,32 @@ class SuperFencesBlockPreprocessor(Preprocessor):
             linestep = m.group('linestep')
             linespecial = m.group('linespecial')
 
-        if self.highlight_code:
-            linestep = self.parse_line_step(linestep)
-            linestart = self.parse_line_start(linestart)
-            linespecial = self.parse_line_special(linespecial)
-            hl_lines = self.parse_hl_lines(hl_lines)
+        linestep = self.parse_line_step(linestep)
+        linestart = self.parse_line_start(linestart)
+        linespecial = self.parse_line_special(linespecial)
+        hl_lines = self.parse_hl_lines(hl_lines)
 
-            el = self.highlighter(
-                guess_lang=self.guess_lang,
-                pygments_style=self.pygments_style,
-                use_pygments=self.use_pygments,
-                noclasses=self.noclasses,
-                linenums=self.linenums,
-                linenums_style=self.linenums_style,
-                linenums_special=self.linenums_special,
-                extend_pygments_lang=self.extend_pygments_lang,
-                wrapcode=self.wrapcode
-            ).highlight(
-                src,
-                language,
-                self.css_class,
-                hl_lines=hl_lines,
-                linestart=linestart,
-                linestep=linestep,
-                linespecial=linespecial
-            )
-        else:
-            # Format as a code block.
-            el = self.CODE_WRAP % ('', '', _escape(src))
+        el = self.highlighter(
+            guess_lang=self.guess_lang,
+            pygments_style=self.pygments_style,
+            use_pygments=self.use_pygments,
+            noclasses=self.noclasses,
+            linenums=self.linenums,
+            linenums_style=self.linenums_style,
+            linenums_special=self.linenums_special,
+            extend_pygments_lang=self.extend_pygments_lang,
+            wrapcode=self.wrapcode
+        ).highlight(
+            src,
+            language,
+            classes,
+            hl_lines=hl_lines,
+            linestart=linestart,
+            linestep=linestep,
+            linespecial=linespecial,
+            id_value=id_value
+        )
+
         return el
 
     def _store(self, source, code, start, end):

--- a/pymdownx/superfences.py
+++ b/pymdownx/superfences.py
@@ -734,8 +734,6 @@ class SuperFencesBlockPreprocessor(Preprocessor):
 
         if classes is None:  # pragma: no cover
             classes = []
-        classes.append(self.css_class)
-        classes = ' '.join(classes)
 
         # Default format options
         linestep = None
@@ -770,11 +768,12 @@ class SuperFencesBlockPreprocessor(Preprocessor):
         ).highlight(
             src,
             language,
-            classes,
+            self.css_class,
             hl_lines=hl_lines,
             linestart=linestart,
             linestep=linestep,
             linespecial=linespecial,
+            classes=classes,
             id_value=id_value
         )
 

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,4 +1,4 @@
-git+https://github.com/squidfunk/mkdocs-material.git@refactor/rxjs-typescript
+mkdocs-material>=5.0.0b1
 git+https://github.com/facelessuser/pymdown-lexers.git
 mkdocs-git-revision-date-localized-plugin
 pyspelling

--- a/tests/extensions/superfences/superfences (custom).html
+++ b/tests/extensions/superfences/superfences (custom).html
@@ -1,1 +1,5 @@
 <div class="test">content</div>
+
+<div id="id" class="class test">content</div>
+
+<pre id="id" class="class test2"><code>content</code></pre>

--- a/tests/extensions/superfences/superfences (custom).txt
+++ b/tests/extensions/superfences/superfences (custom).txt
@@ -1,3 +1,11 @@
 ```test
 content
 ```
+
+```{.test .class #id}
+content
+```
+
+```{.test2 .class #id}
+content
+```

--- a/tests/extensions/superfences/superfences (failures).html
+++ b/tests/extensions/superfences/superfences (failures).html
@@ -97,3 +97,35 @@ Will
 </blockquote>
 </li>
 </ul>
+<hr />
+<ul>
+<li>
+<p>Bad attribute list</p>
+<p><code>{ python }
+import test</code></p>
+</li>
+</ul>
+<hr />
+<ul>
+<li>
+<p>Missing closing bracket</p>
+<p><code>{ .python
+import test</code></p>
+</li>
+</ul>
+<hr />
+<ul>
+<li>
+<p>Missing opening bracket</p>
+<p><code>.python }
+import test</code></p>
+</li>
+</ul>
+<hr />
+<ul>
+<li>
+<p>Additional class outside of attribute list</p>
+<p><code>python .class
+import test</code></p>
+</li>
+</ul>

--- a/tests/extensions/superfences/superfences (failures).txt
+++ b/tests/extensions/superfences/superfences (failures).txt
@@ -90,3 +90,35 @@ Will
      Will
      break
 ```
+
+---
+
+- Bad attribute list
+
+    ``` { python }
+    import test
+    ```
+
+---
+
+- Missing closing bracket
+
+    ``` { .python
+    import test
+    ```
+
+---
+
+- Missing opening bracket
+
+    ``` .python }
+    import test
+    ```
+
+---
+
+- Additional class outside of attribute list
+
+    ```python .class
+    import test
+    ```

--- a/tests/extensions/superfences/superfences (no highlight).html
+++ b/tests/extensions/superfences/superfences (no highlight).html
@@ -1,1 +1,0 @@
-<pre><code>import test</code></pre>

--- a/tests/extensions/superfences/superfences (no highlight).txt
+++ b/tests/extensions/superfences/superfences (no highlight).txt
@@ -1,3 +1,0 @@
-```python
-import test
-```

--- a/tests/extensions/superfences/superfences (no pygments).html
+++ b/tests/extensions/superfences/superfences (no pygments).html
@@ -1,10 +1,10 @@
 <pre><code class="highlight language-python">import test</code></pre>
 
 <p>Text after code.</p>
-<pre><code class="highlight language-python linenums">import test</code></pre>
+<pre><code class="highlight language-python">import test</code></pre>
 
 <h1>Attribute List</h1>
-<pre id="id"><code class="another-class highlight language-python linenums">"""Some file."""
+<pre id="id"><code class="another-class highlight language-python">"""Some file."""
 import foo.bar
 import boo.baz
 import foo.bar.baz</code></pre>

--- a/tests/extensions/superfences/superfences (no pygments).html
+++ b/tests/extensions/superfences/superfences (no pygments).html
@@ -1,4 +1,10 @@
-<pre class="highlight"><code class="language-python">import test</code></pre>
+<pre><code class="highlight language-python">import test</code></pre>
 
 <p>Text after code.</p>
-<pre class="highlight"><code class="language-python linenums">import test</code></pre>
+<pre><code class="highlight language-python linenums">import test</code></pre>
+
+<h1>Attribute List</h1>
+<pre id="id"><code class="another-class highlight language-python linenums">"""Some file."""
+import foo.bar
+import boo.baz
+import foo.bar.baz</code></pre>

--- a/tests/extensions/superfences/superfences (no pygments).html
+++ b/tests/extensions/superfences/superfences (no pygments).html
@@ -1,10 +1,10 @@
-<pre><code class="highlight language-python">import test</code></pre>
+<pre class="highlight"><code class="language-python">import test</code></pre>
 
 <p>Text after code.</p>
-<pre><code class="highlight language-python">import test</code></pre>
+<pre class="highlight"><code class="language-python linenums">import test</code></pre>
 
 <h1>Attribute List</h1>
-<pre id="id"><code class="another-class highlight language-python">"""Some file."""
+<pre id="id" class="highlight"><code class="another-class language-python linenums">"""Some file."""
 import foo.bar
 import boo.baz
 import foo.bar.baz</code></pre>

--- a/tests/extensions/superfences/superfences (no pygments).txt
+++ b/tests/extensions/superfences/superfences (no pygments).txt
@@ -7,3 +7,12 @@ Text after code.
 ```python linenums="1"
 import test
 ```
+
+# Attribute List
+
+```{ .python #id .another-class linenums="1" }
+"""Some file."""
+import foo.bar
+import boo.baz
+import foo.bar.baz
+```

--- a/tests/extensions/superfences/superfences (normal).html
+++ b/tests/extensions/superfences/superfences (normal).html
@@ -145,3 +145,14 @@ A-&gt;B: Normal line
 B--&gt;C: Dashed line
 C-&gt;&gt;D: Open arrow
 D--&gt;&gt;A: Dashed open arrow</code></pre>
+
+<h1>Attribute List</h1>
+<table class="another-class highlighttable"><tr><td class="linenos"><div class="linenodiv"><pre><span></span>1
+2
+3
+4</pre></div></td><td class="code"><div class="another-class highlight"><pre><span></span><code><span class="sd">&quot;&quot;&quot;Some file.&quot;&quot;&quot;</span>
+<span class="hll"><span class="kn">import</span> <span class="nn">foo.bar</span>
+</span><span class="hll"><span class="kn">import</span> <span class="nn">boo.baz</span>
+</span><span class="kn">import</span> <span class="nn">foo.bar.baz</span>
+</code></pre></div>
+</td></tr></table>

--- a/tests/extensions/superfences/superfences (normal).txt
+++ b/tests/extensions/superfences/superfences (normal).txt
@@ -139,3 +139,12 @@ B-->C: Dashed line
 C->>D: Open arrow
 D-->>A: Dashed open arrow
 ```
+
+# Attribute List
+
+```{ .python #id .another-class hl_lines="2 3" linenums="1" }
+"""Some file."""
+import foo.bar
+import boo.baz
+import foo.bar.baz
+```

--- a/tests/extensions/superfences/tests.yml
+++ b/tests/extensions/superfences/tests.yml
@@ -7,11 +7,13 @@ superfences (custom):
         - name: test
           class: test
           format: !!python/name:pymdownx.superfences.fence_div_format
+        - name: test2
+          class: test2
+          format: !!python/name:pymdownx.superfences.fence_code_format
 
 superfences (failures):
   extensions:
     pymdownx.superfences:
-      highlight_code: false
       custom_fences:
         - name: flow
           class: uml-flowchart
@@ -26,18 +28,6 @@ superfences (no indent blocks):
       guess_lang: false
     pymdownx.superfences:
       disable_indented_code_blocks: true
-      custom_fences:
-        - name: flow
-          class: uml-flowchart
-          format: !!python/name:pymdownx.superfences.fence_code_format
-        - name: sequence
-          class: uml-sequence-diagram
-          format: !!python/name:pymdownx.superfences.fence_code_format
-
-superfences (no highlight):
-  extensions:
-    pymdownx.superfences:
-      highlight_code: false
       custom_fences:
         - name: flow
           class: uml-flowchart

--- a/tests/test_extensions/test_highlight.py
+++ b/tests/test_extensions/test_highlight.py
@@ -32,6 +32,102 @@ class TestHighlightInline(util.MdCase):
         )
 
 
+class TestNoClass(util.MdCase):
+    """Test no class."""
+
+    extension = ['pymdownx.highlight', 'pymdownx.superfences']
+    extension_configs = {
+        'pymdownx.highlight': {
+            'css_class': ''
+        }
+    }
+
+    def test_no_class(self):
+        """Test with no class."""
+
+        self.check_markdown(
+            r'''
+            ```python
+            import test
+            test.test()
+            ```
+            ''',
+            r'''
+            <div><pre><span></span><code><span class="kn">import</span> <span class="nn">test</span>
+            <span class="n">test</span><span class="o">.</span><span class="n">test</span><span class="p">()</span>
+            </code></pre></div>
+            ''',  # noqa: E501
+            True
+        )
+
+    def test_no_class_and_user_class(self):
+        """Test with no class and user class."""
+
+        self.check_markdown(
+            r'''
+            ```{.python .more}
+            import test
+            test.test()
+            ```
+            ''',
+            r'''
+            <div class="more"><pre><span></span><code><span class="kn">import</span> <span class="nn">test</span>
+            <span class="n">test</span><span class="o">.</span><span class="n">test</span><span class="p">()</span>
+            </code></pre></div>
+            ''',  # noqa: E501
+            True
+        )
+
+    def test_no_class_and_user_class_linenums(self):
+        """Test with no class and user class and table format."""
+
+        self.check_markdown(
+            r'''
+            ```{.python .more linenums="1"}
+            import test
+            test.test()
+            ```
+            ''',
+            r'''
+            <table class="more table"><tr><td class="linenos"><div class="linenodiv"><pre><span></span>1
+            2</pre></div></td><td class="code"><div class="more "><pre><span></span><code><span class="kn">import</span> <span class="nn">test</span>
+            <span class="n">test</span><span class="o">.</span><span class="n">test</span><span class="p">()</span>
+            </code></pre></div>
+            </td></tr></table>
+            ''',  # noqa: E501
+            True
+        )
+
+
+class TestNoClassNoPygments(util.MdCase):
+    """Test no class."""
+
+    extension = ['pymdownx.highlight', 'pymdownx.superfences']
+    extension_configs = {
+        'pymdownx.highlight': {
+            'css_class': '',
+            'use_pygments': False
+        }
+    }
+
+    def test_no_class_no_pygments(self):
+        """Test with no class and no Pygments."""
+
+        self.check_markdown(
+            r'''
+            ```python
+            import test
+            test.test()
+            ```
+            ''',
+            r'''
+            <pre><code class="language-python">import test
+            test.test()</code></pre>
+            ''',  # noqa: E501
+            True
+        )
+
+
 class TestHighlightSpecial(util.MdCase):
     """Test highlight global special."""
 

--- a/tests/test_extensions/test_inlinehilite.py
+++ b/tests/test_extensions/test_inlinehilite.py
@@ -131,7 +131,7 @@ class TestInlineHiliteNoClass(util.MdCase):
 
         self.check_markdown(
             r'Lets test inline highlight no guessing and no text styling `#!python import module`.',
-            r'<p>Lets test inline highlight no guessing and no text styling <code><span class="kn">import</span> <span class="nn">module</span></code>.</p>'
+            r'<p>Lets test inline highlight no guessing and no text styling <code><span class="kn">import</span> <span class="nn">module</span></code>.</p>'  # noqa: E501
         )
 
 
@@ -150,7 +150,7 @@ class TestInlineHiliteNoClassNoPygments(util.MdCase):
     }
 
     def test_no_class_no_pygments(self):
-        """Test with no class and no pygments."""
+        """Test with no class and no Pygments."""
 
         self.check_markdown(
             r'Lets test inline highlight no guessing and no text styling `#!python import module`.',

--- a/tests/test_extensions/test_inlinehilite.py
+++ b/tests/test_extensions/test_inlinehilite.py
@@ -113,6 +113,51 @@ class TestInlineHilitePlainText(util.MdCase):
         )
 
 
+class TestInlineHiliteNoClass(util.MdCase):
+    """Test with no class."""
+
+    extension = [
+        'pymdownx.highlight',
+        'pymdownx.inlinehilite',
+    ]
+    extension_configs = {
+        'pymdownx.highlight': {
+            'css_class': ''
+        }
+    }
+
+    def test_no_class(self):
+        """Test with no class."""
+
+        self.check_markdown(
+            r'Lets test inline highlight no guessing and no text styling `#!python import module`.',
+            r'<p>Lets test inline highlight no guessing and no text styling <code><span class="kn">import</span> <span class="nn">module</span></code>.</p>'
+        )
+
+
+class TestInlineHiliteNoClassNoPygments(util.MdCase):
+    """Test with no class and no Pygments."""
+
+    extension = [
+        'pymdownx.highlight',
+        'pymdownx.inlinehilite',
+    ]
+    extension_configs = {
+        'pymdownx.highlight': {
+            'css_class': '',
+            'use_pygments': False
+        }
+    }
+
+    def test_no_class_no_pygments(self):
+        """Test with no class and no pygments."""
+
+        self.check_markdown(
+            r'Lets test inline highlight no guessing and no text styling `#!python import module`.',
+            r'<p>Lets test inline highlight no guessing and no text styling <code class="language-python">import module</code>.</p>'  # noqa: E501
+        )
+
+
 class TestInlineHiliteNoPygments(util.MdCase):
     """Test inline highlight without Pygments."""
 


### PR DESCRIPTION
- Add PHP markdown style insertion of classes and ids with attr lists
- Deprecate 'highlight_code' global option in SuperFences. It was true
  by default and disabling it doesn't make sense. It now does nothing
  and will be removed in the future.

Closes #798