### PR TITLE
Inlinehilite: Add a default_lang config setting

### DIFF
--- a/docs/src/markdown/extensions/inlinehilite.md
+++ b/docs/src/markdown/extensions/inlinehilite.md
@@ -121,6 +121,7 @@ Option                    | Type         | Default       | Description
 `css_class`               | string       | `#!py3 ''`    | Class name is applied to the wrapper element of the code. If configured, this setting will override the `css_class` option of Highlight. If nothing is configured here or via or Highlight, the class `highlight` will be used.
 `style_plain_text`        | bool         | `#!py3 False` | When `guess_lang` is set to `#!py3 False`, InlineHilite will avoid applying classes to code blocks that do not explicitly set a language. If it is desired to have plain text styled like code, enable this to inject classes so that they can all be styled the same.
 `custom_inline`           | [dictionary] | `#!py3 []`    | Custom inline code blocks.
+`default_lang`            | string       | `#!py3 ''`    | Code blocks that do not explicitly set a language will default to this; useful for documents that primarily expect to use a single language.
 
 ---8<---
 links.txt

--- a/pymdownx/inlinehilite.py
+++ b/pymdownx/inlinehilite.py
@@ -107,6 +107,7 @@ class InlineHilitePattern(InlineProcessor):
         if not self.get_hl_settings:
             self.get_hl_settings = True
             self.style_plain_text = self.config['style_plain_text']
+            self.default_lang = self.config['default_lang']
 
             config = None
             self.highlighter = None
@@ -130,7 +131,7 @@ class InlineHilitePattern(InlineProcessor):
     def highlight_code(self, src, language, classname=None, md=None):
         """Syntax highlight the inline code block."""
 
-        process_text = self.style_plain_text or language or self.guess_lang
+        process_text = self.style_plain_text or language or self.default_lang or self.guess_lang
 
         if process_text:
             el = self.highlighter(
@@ -139,7 +140,7 @@ class InlineHilitePattern(InlineProcessor):
                 use_pygments=self.use_pygments,
                 noclasses=self.noclasses,
                 extend_pygments_lang=self.extend_pygments_lang
-            ).highlight(src, language, self.css_class, inline=True)
+            ).highlight(src, language or self.default_lang, self.css_class, inline=True)
             el.text = self.md.htmlStash.store(el.text)
         else:
             el = etree.Element('code')
@@ -183,6 +184,10 @@ class InlineHiliteExtension(Extension):
                 "When 'False', no classes will be added to 'text' code blocks"
                 "and no scoping will performed. The content will just be escaped."
                 "- Default: False"
+            ],
+            'default_lang': [
+                None,
+                "When no language is specified, default to this language."
             ],
             'css_class': [
                 '',

--- a/pymdownx/inlinehilite.py
+++ b/pymdownx/inlinehilite.py
@@ -107,7 +107,7 @@ class InlineHilitePattern(InlineProcessor):
         if not self.get_hl_settings:
             self.get_hl_settings = True
             self.style_plain_text = self.config['style_plain_text']
-            self.default_lang = self.config['default_lang']
+            self.default_lang = self.config['default_lang'] or None
 
             config = None
             self.highlighter = None
@@ -186,7 +186,7 @@ class InlineHiliteExtension(Extension):
                 "- Default: False"
             ],
             'default_lang': [
-                None,
+                '',
                 "When no language is specified, default to this language."
             ],
             'css_class': [

--- a/tests/test_extensions/test_inlinehilite.py
+++ b/tests/test_extensions/test_inlinehilite.py
@@ -214,6 +214,33 @@ class TestInlineHiliteGuess(util.MdCase):
         )
 
 
+class TestInlineHiliteDefaultLang(util.MdCase):
+    """Test inline highlight with default language."""
+
+    extension = [
+        'pymdownx.highlight',
+        'pymdownx.inlinehilite',
+    ]
+    extension_configs = {
+        'pymdownx.highlight': {
+            'guess_lang': False
+        },
+        'pymdownx.inlinehilite': {
+            'css_class': 'inlinehilite',
+            'style_plain_text': False,
+            'default_lang': 'py3'
+        }
+    }
+
+    def test_default_language(self):
+        """Ensure a default language is used."""
+
+        self.check_markdown(
+            r'`import module`.',
+            r'<p><code class="inlinehilite"><span class="kn">import</span> <span class="nn">module</span></code>.</p>'
+        )
+
+
 class TestInlineHiliteCodeHilite(util.MdCase):
     """Test inline highlight with CodeHilite."""
 


### PR DESCRIPTION
## Description

Adds a configuration option to inlinehilite to make code blocks without a specified language default to a given language.

### Updates

1. Adds the configuration option
2. Adds logic to handle defaulting
3. Adds a unit test
4. Adds the option to the inlinehilite docs

### Testing

I'm using it on a moderate sized document; also ran the inlinehilite unit tests to ensure no regression.

### Use case

I'm working on [a language specification](https://contravariance.gitlab.io/tenet-site/spec-expr-value.html) and I wind up with a ton of short snippets of code. It's a document about a single language and it's a custom lexer, so simply "use this language unless I say so" seems like the most expedient route.

If it's possible with `custom_inline`, I couldn't figure it out, and I'm using `mkdocs` so I'm stuck with whatever can be expressed in YAML.