### PR TITLE
Fix Fatal Unpacking Bug

### DIFF
--- a/pymdownx/superfences.py
+++ b/pymdownx/superfences.py
@@ -847,7 +847,7 @@ class SuperFencesBlockPreprocessor(Preprocessor):
                 key = m.group(2)
                 indent_level = len(m.group(1))
                 original = None
-                original, pos = self.extension.stash.get(key)
+                original, pos = self.extension.stash.get(key, (None, None))
                 if original is not None:
                     code = self.reindent(original, pos, indent_level)
                     new_lines.extend(code)


### PR DESCRIPTION
With some combination of extensions and syntax, the stash `get` can fail here. Because the default is None, and None is not unpackable, this escalates and crashes the entire suite. This fixes that.