### PR TITLE
Update variable to be `def_non_std_image_path`

### DIFF
--- a/pymdownx/emoji.py
+++ b/pymdownx/emoji.py
@@ -112,7 +112,7 @@ def to_png(index, shortname, alias, uc, alt, title, category, options, md):
         def_non_std_image_path = GITHUB_CDN
     elif index == 'twemoji':
         def_image_path = TWEMOJI_PNG_CDN
-        def_image_path = TWEMOJI_PNG_CDN
+        def_non_std_image_path = TWEMOJI_PNG_CDN
     else:
         def_image_path = EMOJIONE_PNG_CDN
         def_non_std_image_path = EMOJIONE_PNG_CDN


### PR DESCRIPTION
When using `twemoji` I noticed if you pass through a name that's not unicode in the index you get unboundlocalerror for `def_non_std_image_path`. I believe everything in the current index is unicode so this likely never comes up but it seems to be a typo since `def_image_path` is defined twice consecutively.