### PR TITLE
Experimental: Embed videos

### DIFF
--- a/docs/src/dictionary/en-custom.txt
+++ b/docs/src/dictionary/en-custom.txt
@@ -20,6 +20,7 @@ CommonMark
 CriticMarkup
 Ctrl
 DOM
+Dailymotion
 Dicts
 Donath
 ElementTree
@@ -110,6 +111,7 @@ UTF
 Uml
 Unescape
 Validators
+Vimeo
 Virtualenv
 Waylan
 YAML
@@ -142,6 +144,7 @@ emojione
 escaper
 eslint
 facelessuser
+fallbacks
 formatter
 formatter's
 formatters

--- a/docs/src/mkdocs.yml
+++ b/docs/src/mkdocs.yml
@@ -153,6 +153,7 @@ markdown_extensions:
   - pymdownx.tabbed:
       alternate_style: true
   - pymdownx.saneheaders:
+  - pymdownx.embed:
 
 extra:
   social:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -153,6 +153,7 @@ markdown_extensions:
   - pymdownx.tabbed:
       alternate_style: true
   - pymdownx.saneheaders:
+  - pymdownx.embed:
 
 extra:
   social:

--- a/pymdownx/embed.py
+++ b/pymdownx/embed.py
@@ -1,0 +1,186 @@
+"""Library for embedding media and such."""
+from markdown import Extension
+from markdown.treeprocessors import Treeprocessor
+from markdown import util as md_util
+import xml.etree.ElementTree as etree
+import re
+import copy
+
+
+class EmbedMediaTreeprocessor(Treeprocessor):
+    """
+    Find video links and parse them up.
+
+    We'll use the image link syntax to identify our links of interest.
+    """
+
+    # Current recognized file extensions
+    MIMES = re.compile(r'(?i).*?\.([a-z0-9]+)$')
+
+    # Default MIME types, but can be overridden
+    # These are just MIME types we know, but some can be
+    # audio or video, and we cannot predict without a type
+    # in those cases. So any of these can be overridden if
+    # a type is provided, but if none is provided, we take
+    # our best guess.
+    MIMEMAP = {
+        'mp4': 'video/mp4',
+        'webm': 'video/webm',
+        'mp3': 'audio/mpeg',
+        'ogg': 'audio/ogg',
+        'wav': 'audio/wav',
+        'flac': 'audio/flac'
+    }
+
+    def __init__(self, md, video_defaults, audio_defaults):
+        """Initialize."""
+
+        self.video_defaults = video_defaults
+        self.audio_defaults = audio_defaults
+
+        super().__init__(md)
+
+    def run(self, root):
+        """Shorten popular git repository links."""
+
+        # Grab the elements of interest and form a parent mapping
+        links = [e for e in root.iter() if e.tag.lower() in ('img',)]
+        parent_map = {c: p for p in root.iter() for c in p}
+
+        # Evaluate links
+        for link in reversed(links):
+
+            # Save the attributes as we will reuse them
+            attrib = copy.copy(link.attrib)
+
+            # See if source matches the audio or video mime type
+            src = attrib.get('src', '')
+            m = self.MIMES.match(src)
+            if m is None:
+                continue
+
+            # Use whatever audio/video type specified or construct our own
+            # Reject any other types
+            mime = m.group(1).lower()
+
+            # We don't know what case the attributes are in, so normalize them.
+            keys = set([k.lower() for k in attrib.keys()])
+
+            # Identify whether we are working with audio or video and save MIME type
+            mtype = ''
+            if 'type' in keys:
+                v = attrib['type']
+                t = v.lower().split('/')[0]
+                if t in ('audio', 'video'):
+                    mtype = v
+                    keys.remove('type')
+            else:
+                mtype = self.MIMEMAP.get(mime, '')
+                attrib['type'] = mtype
+
+            # Doesn't look like audio/video
+            if not mtype:
+                continue
+
+            # Setup attributess for `<source>` element
+            vtype = mtype[:5].lower()
+            attrib = {**copy.deepcopy(self.video_defaults if vtype == 'video' else self.audio_defaults), **attrib}
+            src_attrib = {'src': src, 'type': mtype}
+            del attrib['src']
+            del attrib['type']
+
+            # Find any other `<source>` specific attributes and check if there is an `alt`
+            alt = ''
+            for k in keys:
+                key = k.lower()
+                if key == 'alt':
+                    alt = attrib[k]
+                    del attrib[k]
+                elif key in ('srcset', 'sizes', 'media'):
+                    src_attrib[key] = attrib[k]
+                    del attrib[key]
+
+            # Build the source element and apply the right type
+            source = etree.Element('source', src_attrib)
+
+            # Find the parent and check if the next sibling is already a media group
+            # that we can attach to. If so, the current link will become the primary
+            # source, and the existing will become the fallback.
+            parent = parent_map[link]
+            one_more = False
+            sibling = None
+            index = -1
+            mtype = src_attrib['type'][:5].lower()
+            for i, c in enumerate(parent, 0):
+                if one_more:
+                    # If there is another sibling, see if it is already a video container
+                    if c.tag.lower() == mtype and 'fallback' in c.attrib:
+                        sibling = c
+                    break
+                if c is link:
+                    # Found where we live, now let's find our sibling
+                    index = i
+                    one_more = True
+
+            # Attach the media source as the primary source, or construct a new group.
+            if sibling is not None:
+                # Insert the source at the top
+                sibling.insert(0, source)
+                # Update container's attributes
+                sibling.attrib.clear()
+                sibling.attrib.update(attrib)
+                # Update fallback link
+                last = list(sibling)[-1]
+                last.attrib['href'] = src
+                last.text = md_util.AtomicString(alt if alt else src)
+            else:
+                # Create media container and insert source
+                media = etree.Element(mtype, attrib)
+                media.append(source)
+                # Just in case the browser doesn't support `<video>` or `<audio>`
+                download = etree.SubElement(media, 'a', {"href": src, "download": ""})
+                download.text = md_util.AtomicString(alt if alt else src)
+                # Insert media where the old link was
+                parent.insert(index, media)
+
+            # Remove the old link
+            parent.remove(link)
+
+        return root
+
+
+class EmbedExtension(Extension):
+    """Add auto link and link transformation extensions to Markdown class."""
+
+    def __init__(self, *args, **kwargs):
+        """Initialize."""
+
+        self.config = {
+            "video_defaults": [
+                {'controls': '', 'preload': 'metadata'},
+                "Video default attributes - Default: {}"
+            ],
+            "audio_defaults": [
+                {'controls': '', 'preload': 'metadata'},
+                "Video default attributes - Default: {}"
+            ]
+        }
+        super().__init__(*args, **kwargs)
+
+    def extendMarkdown(self, md):
+        """Add support for turning html links and emails to link tags."""
+
+        config = self.getConfigs()
+
+        media = EmbedMediaTreeprocessor(
+            md,
+            config['video_defaults'],
+            config['audio_defaults']
+        )
+        md.treeprocessors.register(media, 'embed', 7.9)
+
+
+def makeExtension(*args, **kwargs):
+    """Return extension."""
+
+    return EmbedExtension(*args, **kwargs)

--- a/pymdownx/magiclink.py
+++ b/pymdownx/magiclink.py
@@ -515,6 +515,7 @@ class MagicShortenerTreeprocessor(Treeprocessor):
         """Get the provider and hash size."""
 
         # Set provider specific variables
+        provider = ''
         if match.group('github'):
             provider = 'github'
         elif match.group('bitbucket'):
@@ -526,6 +527,7 @@ class MagicShortenerTreeprocessor(Treeprocessor):
     def get_social_provider(self, match):
         """Get social provider."""
 
+        provider = ''
         if match.group('twitter'):
             provider = 'twitter'
         return provider
@@ -533,6 +535,7 @@ class MagicShortenerTreeprocessor(Treeprocessor):
     def get_type(self, provider, match):
         """Get the link type."""
 
+        value = link_type = None
         try:
             # Gather info about link type
             if match.group(provider + '_diff1') is not None:


### PR DESCRIPTION
## Embedding Video/Audio File Types

Resolves #897 

This is an experimental branch that explores syntax to embed media. The idea is to use the existing `![]()` syntax that has been historically used for images, and instead, use it for media in general.

```
![](mov.webm)
```

"Img" links are processed as normal, and once `attr_list` has processed them, we intercept them in a Treeprocessor. There we identify any links that appear to be media links. Once we've found such links we wrap them in their appropriate element tag (`<video>` or `<audio>`). Inside the "media" tag, the video or audio file with be specified via a `<source>` element.

We do have a default mapping for some known extension types, but some can be either audio or video, if our default assumption is incorrect, the user should specify the `type` attribute using `attr_list`.

Since these are processed after `attr_list`, this means we can apply whatever attributes we want to the element(s) and leverage those. When we are processing the attributes attached to the given tag, we can sort them based on whether they are appropriate for the `<source>` (or `<track>` -- subtitles) element or the parent container.

For instance, here we set `preload` to `metadata` for the media container.

```
![](mov.webm){preload=metadata}
```

But here, since `webm` can be ambiguous, and we default to assuming `video`, we can specify on the `<source>` element that the type is `audio/webm`. Since we are aware of which attributes are `<source>` specific, we can specify them together and it will all get sorted out.

```
![](mov.webm){type="audio/webm" preload=metadata}
```

Anything non-specific to either element will be attached at the parent container level.

If desired, a user can specify globally, via options, a set of default attributes to apply on every media object. If a user explicitly sets that attribute on a media object, the global value will of course be overridden.

For all videos, we will specify a fallback, the last resort for when the video or audio isn't handled. It is a simple message that allows the user to try and download the file directly. 

```html
<video controls preload="metadata">
<source src="https://dl8.webmfiles.org/elephants-dream.webm" type="video/webm">
<a download="" href="https://dl8.webmfiles.org/elephants-dream.webm">https://dl8.webmfiles.org/elephants-dream.webm</a>
</video>
```

If the user provides an `alt`, we will use that to provide a description -- in the case that no `alt` is specified and a title is, title can double as an alt. Assuming none of these are provided, the fallback will simply be the source link.

```html
<video controls preload="metadata"><source src="https://dl8.webmfiles.org/elephants-dream.webm" type="video/webm"><source src="./images/elephants-dream.webm" type="video/webm">
<a download="" href="https://dl8.webmfiles.org/elephants-dream.webm">Elephant has a dream</a>
</video>
```

Lastly, we provide a mechanism for fallback sources. If multiple, same types of media (audio or video) are grouped together, the first one will be assumed as the main video, and all others will be assumed fallbacks if they specify the `fallback` attribute. This can be used to specify multiple video types in case a browser does not support one type. Additionally, `.vtt` sources can be used and will be included in whatever the parent is, audio or video -- `.vtt` sources are inserted as `<track>` elements, not `<source>`.

```
![A movie about stuff](mov.webm)
![](mov.mp4){fallback}
```

```html
<video controls= preload="metadata">
<source src="mov.webm" type="video/webm">
<source src="mov.mp4" type="video/mp4">
<a download="" href="mov.webm">mov.webm</a>
</video>
```

Source-specific attributes will apply to each source, but the "media" and general attributes will be taken only from the main source.

```
![Audio about stuff](audio.mp3){loop=''}
![](audio.webm){fallback type="audio/webm"}
```

```html
<audio controls loop preload="metadata">
<source src="audio.mp3" type="audio/mpeg">
<source src="audio.webm" type="audio/webm">
<a download="" href="audio.mp3">Audio about stuff</a>
</audio>
```

## Embedding Media Services

Resolves #896 

Embedding video services such as Youtube uses the same syntax as the above `![some alt text](youtube.link)`. These media links will be converted to an appropriate embedded link and wrapped in an `<iframe>`.

`<iframe>` have no concept of `alt`, but it is generally encouraged that a `title` is applied. So in this case, `alt` will double as a `title` if `title` is not defined. If neither `alt` or `title` is defined, something generic like `YouTube video player` will be provided via the default configuration.

```
![Random YouTube link](https://www.youtube.com/embed/ZTjzHsAU5-U)
```

```html
<iframe allowfullscreen="" frameborder="0" src="https://www.youtube.com/embed/ZTjzHsAU5-U" title="Random YouTube link"></iframe>
```

Things are abstracted in such a way that someone could provide their own function for a specific video service, but as of right now, only: Vimeo, YouTube, and Dailymotion are supported out of the box.

Global default attributes can be defined per media service.

Feedback is welcome!




