### PR TITLE
If linenums is globally true allow disabling linenums per block

### DIFF
--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -2,6 +2,8 @@
 
 ## 9.1
 
+- **NEW**: Highlight: If `linenums` is enabled globally via the `highlight` extension, and a code block specifies a line
+  number of zero (e.g. SuperFences), disable line numbers for that code block.
 - **FIX**: When `attr_list` is enabled, attributes were not properly added to Pygments code blocks in the `table`
   format. (#1505)
 

--- a/pymdownx/__meta__.py
+++ b/pymdownx/__meta__.py
@@ -185,5 +185,5 @@ def parse_version(ver, pre=False):
     return Version(major, minor, micro, release, pre, post, dev)
 
 
-__version_info__ = Version(9, 0, 0, "final")
+__version_info__ = Version(9, 1, 0, ".dev")
 __version__ = __version_info__._get_canonical()

--- a/pymdownx/highlight.py
+++ b/pymdownx/highlight.py
@@ -309,7 +309,10 @@ class Highlight(object):
         if attrs is None:
             attrs = {}
         class_names = classes[:] if classes else []
-        linenums_enabled = (self.linenums or (self.linenums is not False and linestart >= 0)) and not inline > 0
+        linenums_enabled = (
+            (self.linenums and linestart != 0) or
+            (self.linenums is not False and linestart > 0)
+        ) and not inline > 0
 
         # Convert with Pygments.
         if pygments and self.use_pygments:

--- a/tests/test_extensions/test_highlight.py
+++ b/tests/test_extensions/test_highlight.py
@@ -453,3 +453,52 @@ class TestDisabledLinenumsNoPygments(util.MdCase):
             ''',  # noqa: E501
             True
         )
+
+
+class TestGlobalLinenums(util.MdCase):
+    """Test global line number cases."""
+
+    extension = ['pymdownx.highlight', 'pymdownx.superfences']
+    extension_configs = {
+        'pymdownx.highlight': {
+            'linenums': True
+        }
+    }
+
+    def test_global_line_numbers(self):
+        """Test that global line numbers works."""
+
+        self.check_markdown(
+            r'''
+            ```python
+            import test
+            test.test()
+            ```
+            ''',
+            r'''
+            <table class="highlighttable"><tr><td class="linenos"><div class="linenodiv"><pre><span></span><span class="normal">1</span>
+            <span class="normal">2</span></pre></div></td><td class="code"><div class="highlight"><pre><span></span><code><span class="kn">import</span> <span class="nn">test</span>
+            <span class="n">test</span><span class="o">.</span><span class="n">test</span><span class="p">()</span>
+            </code></pre></div>
+            </td></tr></table>
+            ''',  # noqa: E501
+            True
+        )
+
+    def test_global_disabling_of_line_numbers(self):
+        """Test that global line numbers can be disabled."""
+
+        self.check_markdown(
+            r'''
+            ```{.python linenums="0"}
+            import test
+            test.test()
+            ```
+            ''',
+            r'''
+            <div class="highlight"><pre><span></span><code><span class="kn">import</span> <span class="nn">test</span>
+            <span class="n">test</span><span class="o">.</span><span class="n">test</span><span class="p">()</span>
+            </code></pre></div>
+            ''',  # noqa: E501
+            True
+        )


### PR DESCRIPTION
A code block in SuperFences can specifying the starting line as zero
to disable global linenums for that specific code block.

Resolves #1486