### PR TITLE
Fix Pygments version requirement

### DIFF
--- a/requirements/extra.txt
+++ b/requirements/extra.txt
@@ -1,1 +1,1 @@
-Pygments>=2.0.1
+Pygments>=2.12


### PR DESCRIPTION
In the latest [release](https://github.com/facelessuser/pymdown-extensions/releases/tag/9.4) this package broke the compatibility with `Pygments < 2.12`. I think we should also change the version range in `requirements`.