### PR TITLE
feat: block language class

### DIFF
--- a/docs/src/markdown/extensions/highlight.md
+++ b/docs/src/markdown/extensions/highlight.md
@@ -79,9 +79,6 @@ wish to apply.
         ]
         ```
 
-!!! new "New 9.2"
-    `pygments_lang_class` added in 9.2.
-
 ## Line Number Styles
 
 Pygments has two available styles when outputting source code with line numbers enabled: `table` and `inline`. `table`
@@ -110,7 +107,7 @@ apply when Pygments is disabled. Many of these options are demonstrated in the [
 Option                    | Type   | Default               | Description
 ------------------------- | ------ | ----------------------| -----------
 `css_class`               | string | `#!py3 'highlight`    | Default class to apply to the wrapper element on code blocks. Other extensions can override this.
-`guess_lang`              | bool   | `#!py3 False`         | Guess what syntax language should be used if no language is specified. 
+`guess_lang`              | bool   | `#!py3 False`         | Guess what syntax language should be used if no language is specified.
 `pygments_style`          | string | `#!py3 'default'`     | Set the Pygments' style to use.  This really only has an effect when used with `noclasses`.
 `noclasses`               | bool   | `#!py3 False`         | This will cause the styles to directly be written to the tag's style attribute instead of requiring a stylesheet.
 `use_pygments`            | bool   | `#!py3 True`          | Controls whether Pygments (if available) is used to style the code, or if the code will just be escaped and prepped for a JavaScript syntax highlighter.
@@ -127,6 +124,7 @@ Option                    | Type   | Default               | Description
 `anchor_linenums`         | bool   | `#!py3 False`         | Enables the Pygments option of a similar name. If set to `#!py True`, will wrap line numbers in `#!html <a>` tags. Used in combination with `linenums` and `line_anchors`. If `line_anchors` is not configured, `__codelineno` will be assumed as the ID prefix.
 `line_anchors`            | bool   | `#!py3 False`         | Controls the Pygments option of a similar name. If set to a nonempty string, e.g. `foo`, the formatter will insert an anchor tag with an id (and name) of `foo-<code_block_number>-<line_number>`.
 `pygments_lang_class`     | bool   | `#!py3 False`         | If set to True, the language name used will be included as a class attached to the element with the associated `language_prefix`.
+`block_lang_class`        | bool   | `#!py3 False`         | If set to True, the block language name will be included as a class attached to the element with the associated `language_prefix`.
 
 !!! new "New 7.1"
     `linenums_class` was added in `7.1`.
@@ -138,3 +136,9 @@ Option                    | Type   | Default               | Description
 
 !!! new "New 9.0"
     `auto_tile`, `auto_title_map`, `line_spans`, `anchor_linenums`, and `line_anchors` were all added in `9.0`.
+
+!!! new "New 9.2"
+    `pygments_lang_class` added in 9.2.
+
+!!! new "New 9.5"
+    `block_lang_class` added in 9.5.

--- a/pymdownx/highlight.py
+++ b/pymdownx/highlight.py
@@ -124,6 +124,10 @@ DEFAULT_CONFIG = {
         False,
         'If set to True, the language name used will be included as a class attached to the element. - Defaults: False'
     ],
+    'block_lang_class': [
+        False,
+        'If set to True, the block language name used will be included as a class attached to the element. - Defaults: False'
+    ],
     '_enabled': [
         True,
         'Used internally to communicate if extension has been explicitly enabled - Default: False'
@@ -230,7 +234,7 @@ class Highlight(object):
         noclasses=False, extend_pygments_lang=None, linenums=None, linenums_special=-1,
         linenums_style='table', linenums_class='linenums', language_prefix='language-',
         code_attr_on_pre=False, auto_title=False, auto_title_map=None, line_spans='',
-        anchor_linenums=False, line_anchors='', pygments_lang_class=False
+        anchor_linenums=False, line_anchors='', pygments_lang_class=False, block_lang_class=False,
     ):
         """Initialize."""
 
@@ -249,6 +253,7 @@ class Highlight(object):
         self.line_anchors = line_anchors
         self.anchor_linenums = anchor_linenums
         self.pygments_lang_class = pygments_lang_class
+        self.block_lang_class = block_lang_class
 
         if self.anchor_linenums and not self.line_anchors:
             self.line_anchors = '__codelineno'
@@ -335,6 +340,8 @@ class Highlight(object):
             lexer, lang_name = self.get_lexer(src, language)
             if self.pygments_lang_class:
                 class_names.insert(0, self.language_prefix + lang_name)
+            if self.block_lang_class:
+                class_names.insert(0, self.language_prefix + language)
             linenums = self.linenums_style if linenums_enabled else False
 
             if class_names:
@@ -497,7 +504,8 @@ class HighlightTreeprocessor(Treeprocessor):
                     code_attr_on_pre=self.config['code_attr_on_pre'],
                     auto_title=self.config['auto_title'],
                     auto_title_map=self.config['auto_title_map'],
-                    pygments_lang_class=self.config['pygments_lang_class']
+                    pygments_lang_class=self.config['pygments_lang_class'],
+                    block_lang_class=self.config['block_lang_class']
                 )
                 placeholder = self.md.htmlStash.store(
                     code.highlight(

--- a/pymdownx/inlinehilite.py
+++ b/pymdownx/inlinehilite.py
@@ -132,6 +132,7 @@ class InlineHilitePattern(InlineProcessor):
             self.noclasses = config['noclasses']
             self.language_prefix = config['language_prefix']
             self.pygments_lang_class = config['pygments_lang_class']
+            self.block_lang_class = config['block_lang_class']
 
     def highlight_code(self, src='', language='', classname=None, md=None):
         """Syntax highlight the inline code block."""
@@ -146,7 +147,8 @@ class InlineHilitePattern(InlineProcessor):
                 noclasses=self.noclasses,
                 extend_pygments_lang=self.extend_pygments_lang,
                 language_prefix=self.language_prefix,
-                pygments_lang_class=self.pygments_lang_class
+                pygments_lang_class=self.pygments_lang_class,
+                block_lang_class=self.block_lang_class
             ).highlight(src, language, self.css_class, inline=True)
             el.text = self.md.htmlStash.store(el.text)
         else:

--- a/pymdownx/superfences.py
+++ b/pymdownx/superfences.py
@@ -392,6 +392,7 @@ class SuperFencesBlockPreprocessor(Preprocessor):
             self.line_anchors = config.get('line_anchors', '')
             self.anchor_linenums = config.get('anchor_linenums', False)
             self.pygments_lang_class = config.get('pygments_lang_class', False)
+            self.block_lang_class = config.get('block_lang_class', False)
 
     def clear(self):
         """Reset the class variables."""
@@ -795,7 +796,8 @@ class SuperFencesBlockPreprocessor(Preprocessor):
             line_spans=self.line_spans,
             line_anchors=self.line_anchors,
             anchor_linenums=self.anchor_linenums,
-            pygments_lang_class=self.pygments_lang_class
+            pygments_lang_class=self.pygments_lang_class,
+            block_lang_class=self.block_lang_class
         ).highlight(
             src,
             language,

--- a/tests/test_extensions/test_highlight.py
+++ b/tests/test_extensions/test_highlight.py
@@ -542,6 +542,45 @@ class TestPygmentsLangClass(util.MdCase):
         )
 
 
+class TestBlockLangClass(util.MdCase):
+    """Test no Pygments with custom line number class."""
+
+    extension = ['pymdownx.highlight', 'pymdownx.inlinehilite', 'pymdownx.superfences']
+    extension_configs = {
+        'pymdownx.highlight': {
+            'block_lang_class': True
+        }
+    }
+
+    def test_superfences(self):
+        """Test language classes with SuperFences."""
+
+        self.check_markdown(
+            r'''
+            ```mermaid
+            graph TD;
+            ```
+            ''',
+            r'''
+            <div class="language-mermaid highlight"><pre><span></span><code>graph TD;
+            </code></pre></div>
+            ''',  # noqa: E501
+            True
+        )
+
+    def test_inlinehilite(self):
+        """Test language classes with InlineHilite."""
+
+        self.check_markdown(
+            '''
+            `#!python import test`
+            ''',
+            '''
+            <p><code class="language-python highlight"><span class="kn">import</span> <span class="nn">test</span></code></p>
+            ''',  # noqa: E501
+            True
+        )
+
 class TestExtendedLang(util.MdCase):
     """Test extended language cases."""
 


### PR DESCRIPTION
Expose the language name used in code block as css class.

Our use-case is doing some client-side processing of mermaid js code blocks, where it would be useful to have access to this information in the rendered output.