### PR TITLE
Allow only guessing language for inline/block code

### DIFF
--- a/docs/src/markdown/extensions/highlight.md
+++ b/docs/src/markdown/extensions/highlight.md
@@ -110,7 +110,7 @@ apply when Pygments is disabled. Many of these options are demonstrated in the [
 Option                    | Type   | Default               | Description
 ------------------------- | ------ | ----------------------| -----------
 `css_class`               | string | `#!py3 'highlight`    | Default class to apply to the wrapper element on code blocks. Other extensions can override this.
-`guess_lang`              | bool   | `#!py3 False`         | Guess what syntax language should be used if no language is specified. 
+`guess_lang`              | bool   | `#!py3 False`         | Guess what syntax language should be used if no language is specified. `#!py3 True` for always, `#!py3 False` for never, `#!py3 'block'` for block code only, and `#!py3 'inline'` for inline code only.
 `pygments_style`          | string | `#!py3 'default'`     | Set the Pygments' style to use.  This really only has an effect when used with `noclasses`.
 `noclasses`               | bool   | `#!py3 False`         | This will cause the styles to directly be written to the tag's style attribute instead of requiring a stylesheet.
 `use_pygments`            | bool   | `#!py3 True`          | Controls whether Pygments (if available) is used to style the code, or if the code will just be escaped and prepped for a JavaScript syntax highlighter.

--- a/pymdownx/highlight.py
+++ b/pymdownx/highlight.py
@@ -52,7 +52,7 @@ DEFAULT_CONFIG = {
         'Default: True'
     ],
     'guess_lang': [
-        False,
+        0,
         "Automatic language detection - Default: False"
     ],
     'css_class': [
@@ -484,7 +484,7 @@ class HighlightTreeprocessor(Treeprocessor):
 
                 self.ext.pygments_code_block += 1
                 code = Highlight(
-                    guess_lang=self.config['guess_lang'],
+                    guess_lang=(self.config['guess_lang'] == True) or (self.config['guess_lang'] == 'block'),
                     pygments_style=self.config['pygments_style'],
                     use_pygments=self.config['use_pygments'],
                     noclasses=self.config['noclasses'],

--- a/pymdownx/highlight.py
+++ b/pymdownx/highlight.py
@@ -291,7 +291,7 @@ class Highlight(object):
             lexer = None
 
         if lexer is None:
-            if self.guess_lang or (self.guess_lang == 'inline' if inline else self.guess_lang == 'block'):
+            if (self.guess_lang is True) or (self.guess_lang == 'inline' if inline else self.guess_lang == 'block'):
                 try:
                     lexer = guess_lexer(src)
                     name = lexer.aliases[0]

--- a/pymdownx/highlight.py
+++ b/pymdownx/highlight.py
@@ -274,7 +274,7 @@ class Highlight(object):
 
         return self.extend_pygments_lang.get(language.lower(), (language, {}))
 
-    def get_lexer(self, src, language):
+    def get_lexer(self, src, language, inline):
         """Get the Pygments lexer."""
 
         name = language
@@ -291,7 +291,7 @@ class Highlight(object):
             lexer = None
 
         if lexer is None:
-            if self.guess_lang:
+            if self.guess_lang or (self.guess_lang == 'inline' if inline else self.guess_lang == 'block'):
                 try:
                     lexer = guess_lexer(src)
                     name = lexer.aliases[0]
@@ -332,7 +332,7 @@ class Highlight(object):
                 raise RuntimeError('Pymdownx Highlight requires at least Pygments 2.12+ if enabling Pygments')
 
             # Setup language lexer.
-            lexer, lang_name = self.get_lexer(src, language)
+            lexer, lang_name = self.get_lexer(src, language, inline)
             if self.pygments_lang_class:
                 class_names.insert(0, self.language_prefix + lang_name)
             linenums = self.linenums_style if linenums_enabled else False
@@ -484,7 +484,7 @@ class HighlightTreeprocessor(Treeprocessor):
 
                 self.ext.pygments_code_block += 1
                 code = Highlight(
-                    guess_lang=(self.config['guess_lang'] == True) or (self.config['guess_lang'] == 'block'),
+                    guess_lang=self.config['guess_lang'],
                     pygments_style=self.config['pygments_style'],
                     use_pygments=self.config['use_pygments'],
                     noclasses=self.config['noclasses'],

--- a/pymdownx/inlinehilite.py
+++ b/pymdownx/inlinehilite.py
@@ -126,7 +126,7 @@ class InlineHilitePattern(InlineProcessor):
             self.css_class = css_class if css_class else config['css_class']
 
             self.extend_pygments_lang = config.get('extend_pygments_lang', None)
-            self.guess_lang = config['guess_lang']
+            self.guess_lang = (config['guess_lang'] == True) or (config['guess_lang'] == 'inline')
             self.pygments_style = config['pygments_style']
             self.use_pygments = config['use_pygments']
             self.noclasses = config['noclasses']

--- a/pymdownx/inlinehilite.py
+++ b/pymdownx/inlinehilite.py
@@ -126,7 +126,7 @@ class InlineHilitePattern(InlineProcessor):
             self.css_class = css_class if css_class else config['css_class']
 
             self.extend_pygments_lang = config.get('extend_pygments_lang', None)
-            self.guess_lang = (config['guess_lang'] == True) or (config['guess_lang'] == 'inline')
+            self.guess_lang = config['guess_lang']
             self.pygments_style = config['pygments_style']
             self.use_pygments = config['use_pygments']
             self.noclasses = config['noclasses']

--- a/tests/test_extensions/test_highlight.py
+++ b/tests/test_extensions/test_highlight.py
@@ -41,7 +41,7 @@ class TestHighlightGuessBlock(util.MdCase):
         }
     }
 
-    def test_guess(self):
+    def test_guess_block(self):
         """Test guessing for block."""
 
         self.check_markdown(
@@ -55,6 +55,18 @@ class TestHighlightGuessBlock(util.MdCase):
             <div class="highlight"><pre><span></span><code><span class="kn">import</span> <span class="nn">test</span>
             <span class="n">test</span><span class="o">.</span><span class="n">test</span><span class="p">()</span>
             </code></pre></div>
+            ''',
+            True
+        )
+
+    def test_no_guess_inline(self):
+        """Test inline code is not language guessed"""
+        self.check_markdown(
+            r'''
+            `int i = std::numeric_limits<int>::min();`
+            ''',
+            '''
+            <p><code>int i = std::numeric_limits&lt;int&gt;::min();</code></p>
             ''',
             True
         )

--- a/tests/test_extensions/test_highlight.py
+++ b/tests/test_extensions/test_highlight.py
@@ -60,7 +60,7 @@ class TestHighlightGuessBlock(util.MdCase):
         )
 
     def test_no_guess_inline(self):
-        """Test inline code is not language guessed"""
+        """Test inline code is not language guessed."""
         self.check_markdown(
             r'''
             `int i = std::numeric_limits<int>::min();`

--- a/tests/test_extensions/test_highlight.py
+++ b/tests/test_extensions/test_highlight.py
@@ -31,6 +31,35 @@ class TestHighlightGuess(util.MdCase):
         )
 
 
+class TestHighlightGuessBlock(util.MdCase):
+    """Test that highlighting works with guessing for block."""
+
+    extension = ['pymdownx.highlight', 'pymdownx.superfences']
+    extension_configs = {
+        'pymdownx.highlight': {
+            'guess_lang': "block"
+        }
+    }
+
+    def test_guess(self):
+        """Test guessing for block."""
+
+        self.check_markdown(
+            r'''
+            ```
+            import test
+            test.test()
+            ```
+            ''',
+            '''
+            <div class="highlight"><pre><span></span><code><span class="kn">import</span> <span class="nn">test</span>
+            <span class="n">test</span><span class="o">.</span><span class="n">test</span><span class="p">()</span>
+            </code></pre></div>
+            ''',
+            True
+        )
+
+
 class TestHighlightAutoTitle(util.MdCase):
     """Test title cases."""
 

--- a/tests/test_extensions/test_inlinehilite.py
+++ b/tests/test_extensions/test_inlinehilite.py
@@ -234,6 +234,7 @@ class TestInlineHiliteGuessInline(util.MdCase):
     extension = [
         'pymdownx.highlight',
         'pymdownx.inlinehilite',
+        'pymdownx.superfences'
     ]
     extension_configs = {
         'pymdownx.highlight': {
@@ -251,6 +252,34 @@ class TestInlineHiliteGuessInline(util.MdCase):
         self.check_markdown(
             r'`import module`.',
             r'<p><code class="inlinehilite"><span class="kn">import</span> <span class="nn">module</span></code>.</p>'
+        )
+
+    def test_no_guessing_block(self):
+        """Ensure block is not guessed when set as inline only."""
+
+        self.check_markdown(
+            r'''
+            ```
+            <!DOCTYPE html>
+            <html>
+            <body>
+            <h1>My great test</h1>
+            <p>Thou shalt be re-educated through labour should this test ever fails.</p>
+            </body>
+            </html>
+            ```
+            ''',
+            r'''
+            <div class="highlight"><pre><span></span><code>&lt;!DOCTYPE html&gt;
+            &lt;html&gt;
+            &lt;body&gt;
+            &lt;h1&gt;My great test&lt;/h1&gt;
+            &lt;p&gt;Thou shalt be re-educated through labour should this test ever fails.&lt;/p&gt;
+            &lt;/body&gt;
+            &lt;/html&gt;
+            </code></pre></div>
+            ''',
+            True
         )
 
 

--- a/tests/test_extensions/test_inlinehilite.py
+++ b/tests/test_extensions/test_inlinehilite.py
@@ -228,6 +228,32 @@ class TestInlineHiliteGuess(util.MdCase):
         )
 
 
+class TestInlineHiliteGuessInline(util.MdCase):
+    """Test inline highlight with guessing set to be inline only."""
+
+    extension = [
+        'pymdownx.highlight',
+        'pymdownx.inlinehilite',
+    ]
+    extension_configs = {
+        'pymdownx.highlight': {
+            'guess_lang': 'inline'
+        },
+        'pymdownx.inlinehilite': {
+            'css_class': 'inlinehilite',
+            'style_plain_text': True
+        }
+    }
+
+    def test_guessing_inline(self):
+        """Ensure guessing can be enabled for inline only."""
+
+        self.check_markdown(
+            r'`import module`.',
+            r'<p><code class="inlinehilite"><span class="kn">import</span> <span class="nn">module</span></code>.</p>'
+        )
+
+
 class TestInlineHiliteCodeHilite(util.MdCase):
     """Test inline highlight with CodeHilite."""
 


### PR DESCRIPTION
There was no way to specify the type of code block to be guessed language, for example, to only guess language for code blocks but not inline code, the length of which is usually insufficient for satisfactory accuracy.

Allow 'inline' and 'block' to be specified for `guess_lang` in addition to boolean values.

Fixes #1696.