### PR TITLE
Suppress expected deprecation warnings from test

### DIFF
--- a/tests/test_extensions/test_emoji.py
+++ b/tests/test_extensions/test_emoji.py
@@ -3,6 +3,7 @@ from .. import util
 import pymdownx.emoji as emoji
 import warnings
 import markdown
+import pytest
 
 
 def _old_style_index():
@@ -23,6 +24,7 @@ def _new_style_index(options, md):
     return index
 
 
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
 class TestEmojiOldIndex(util.MdCase):
     """Test old style index."""
 

--- a/tests/test_extensions/test_legacy_slugs.py
+++ b/tests/test_extensions/test_legacy_slugs.py
@@ -2,6 +2,9 @@
 """Test slugs."""
 from .. import util
 from pymdownx import slugs
+import pytest
+
+pytestmark = pytest.mark.filterwarnings('ignore::DeprecationWarning')
 
 
 class TestUslugify(util.MdCase):


### PR DESCRIPTION
There are tests specifically targeting legacy/deprecated features, where `DeprecationWarning`'s are expected and should not be displayed.

Suppress these with pytest markers to reduce noise.

https://docs.pytest.org/en/6.2.x/warnings.html#pytest-mark-filterwarnings