### PR TITLE
fix: use get_pymdownx_highlighter consistently

### DIFF
--- a/pymdownx/highlight.py
+++ b/pymdownx/highlight.py
@@ -22,6 +22,7 @@ All changes Copyright 2008-2014 The Python Markdown Project
 License: [BSD](http://www.opensource.org/licenses/bsd-license.php)
 """
 import re
+from typing import Type
 from markdown import Extension
 from markdown.treeprocessors import Treeprocessor
 import xml.etree.ElementTree as etree
@@ -483,7 +484,8 @@ class HighlightTreeprocessor(Treeprocessor):
             if len(block) == 1 and block[0].tag == 'code':
 
                 self.ext.pygments_code_block += 1
-                code = Highlight(
+                highlight_class : Type[Highlight] = self.ext.get_pymdownx_highlighter()
+                code = highlight_class(
                     guess_lang=self.config['guess_lang'],
                     pygments_style=self.config['pygments_style'],
                     use_pygments=self.config['use_pygments'],


### PR DESCRIPTION
Awesome library, nice work.

I wanted to have custom behavior where markdown code gets executed and add a little widget as output under the code. This can be easily implemented by subclassing the `Highlight` class and overriding `def highlight(...)`. 

However, there was one place where the Highlight class was directly used, instead of via `get_pymdownx_highlighter` (which can also be overridden).

Let me know if you think this is a good usage of your library, and if you think this API will be stable in the future?

FYI, this is how I implement this:

```python
class Highlight(pymdownx.highlight.Highlight):
    def highlight(self, src, language, *args, **kwargs):
        run_src_with_solara = False
        if language == "solara":
            run_src_with_solara = True
            language = "python"
        html = super().highlight(src, language, *args, **kwargs)
        if run_src_with_solara:
            html_widget = run_solara(src)
            return html + html_widget
        else:
            return html


class HighlightExtension(pymdownx.highlight.HighlightExtension):
    def get_pymdownx_highlighter(self):
        return Highlight

```

Regards,

Maarten
