### PR TITLE
Fixed class name

### DIFF
--- a/docs/src/markdown/about/releases/7.0.md
+++ b/docs/src/markdown/about/releases/7.0.md
@@ -6,7 +6,7 @@ A new extension called Tabbed has been added. With the arrival of this general p
 made the old SuperFences tabbed content feature redundant. By default, SuperFences will now change the classes it uses
 for it's tabbed feature to match those of the new Tabbed extension. CSS should be updated accordingly.
 
-The classes that have changed are `supferfences-tabs` and `superfences-content`, which have changed to `tabbed-set` and
+The classes that have changed are `superfences-tabs` and `superfences-content`, which have changed to `tabbed-set` and
 `tabbed-content` respectively. Example CSS is updated in SuperFences for
 [reference](../../extensions/superfences.md).
 


### PR DESCRIPTION
Looks like there is a typo in line 9 `supferfences-tabs`. Therefore, I changed it to `superfences-tabs` in order to fix the error.