### PR TITLE
Add tip to avoid trailing whitespace

### DIFF
--- a/docs/src/markdown/extensions/superfences.md
+++ b/docs/src/markdown/extensions/superfences.md
@@ -58,17 +58,17 @@ md = markdown.Markdown(extensions=['pymdownx.superfences'])
     ````
 
 7. If using a fenced block as the first line of a list, you will have to leave the first line blank, but remember that
-  the list marker must be followed by a space. To avoid the trailing whitespace that might be removed by your IDE,
-  just add an extra unicode space (`&#32;`).
+  the list marker must be immediately followed by at least one space. To avoid accidentally deleting the space and to
+  make your intentions clear, you might want to also add an explicit unicode space (`&#32;`) as shown here:
 
     ````
-    -<space>&#32;
+    - &#32;
         ```
         a fenced block
         ```
 
     Definition
-    :<space>&#32;
+    : &#32;
         ```
         a fenced block
         ```

--- a/docs/src/markdown/extensions/superfences.md
+++ b/docs/src/markdown/extensions/superfences.md
@@ -58,16 +58,17 @@ md = markdown.Markdown(extensions=['pymdownx.superfences'])
     ````
 
 7. If using a fenced block as the first line of a list, you will have to leave the first line blank, but remember that
-  the list marker must be followed by a space.
+  the list marker must be followed by a space. To avoid the trailing whitespace that might be removed by your IDE,
+  just add an extra unicode space (`&#32;`).
 
     ````
-    -<space>
+    -<space>&#32;
         ```
         a fenced block
         ```
 
     Definition
-    :<space>
+    :<space>&#32;
         ```
         a fenced block
         ```


### PR DESCRIPTION
Because a whitespace is required for fenced code blocks on the first line of a list item, it's a better practice to include an explicit whitespace so it does not get accidentally removed. (Using `&nbsp;` does not have the same effect because that character gets parsed into the HTML as a character string so you end up with a blank line before the code block, whereas the unicode space gets collapsed and ignored by the Markdown parser.)