### PR TITLE
Fix extraneous newlines in indented code blocks with use_pygments=False

### DIFF
--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 9.9.3
+
+- **FIX**: Highlight: Remove extraneous new lines from end of indented code blocks when using
+  `#!py use_pygments = False`.
+
 ## 9.9.2
 
 - **FIX**: Snippets syntax can break in XML comments as XML comments do not allow `--`. Relax Snippets syntax such that

--- a/pymdownx/__meta__.py
+++ b/pymdownx/__meta__.py
@@ -185,5 +185,5 @@ def parse_version(ver, pre=False):
     return Version(major, minor, micro, release, pre, post, dev)
 
 
-__version_info__ = Version(9, 9, 2, "final")
+__version_info__ = Version(9, 9, 3, "final")
 __version__ = __version_info__._get_canonical()

--- a/pymdownx/highlight.py
+++ b/pymdownx/highlight.py
@@ -501,7 +501,7 @@ class HighlightTreeprocessor(Treeprocessor):
                 )
                 placeholder = self.md.htmlStash.store(
                     code.highlight(
-                        self.code_unescape(block[0].text),
+                        self.code_unescape(block[0].text).rstrip('\n'),
                         '',
                         self.config['css_class'],
                         code_block_count=self.ext.pygments_code_block

--- a/tests/test_extensions/test_highlight.py
+++ b/tests/test_extensions/test_highlight.py
@@ -335,6 +335,28 @@ class TestNoPygments(util.MdCase):
             True
         )
 
+    def test_no_pygments_extraneous_new_lines(self):
+        """Test that extraneous new lines are not included."""
+
+        self.check_markdown(
+            r'''
+            Test
+
+                import test
+                test.test()
+
+
+            Test
+            ''',
+            r'''
+            <p>Test</p>
+            <pre class="highlight"><code>import test
+            test.test()</code></pre>
+            <p>Test</p>
+            ''',
+            True
+        )
+
 
 class TestNoPygmentsCustomLineClass(util.MdCase):
     """Test no Pygments with custom line number class."""
@@ -363,8 +385,7 @@ class TestNoPygmentsCustomLineClass(util.MdCase):
             r'''
             <p>Text</p>
             <pre class="highlight"><code>import test
-            test.test()
-            </code></pre>
+            test.test()</code></pre>
             <p>Text</p>
             ''',
             True


### PR DESCRIPTION
Fixes #1928