### PR TITLE
Fixed Python 3.12 DeprecationWarning

### DIFF
--- a/pymdownx/details.py
+++ b/pymdownx/details.py
@@ -85,7 +85,7 @@ class DetailsProcessor(BlockProcessor):
             # to be under it, then the content's is sibling is in the list.
             last_child = self.lastChild(sibling)
             indent = 0
-            while last_child:
+            while last_child is not None:
                 if (
                     sibling and block.startswith(' ' * self.tab_length * 2) and
                     last_child and last_child.tag in ('ul', 'ol', 'dl')


### PR DESCRIPTION
Testing an element's truth value will raise an exception in future versions.