### PR TITLE
Add highlight lexer cache to improve performance

### DIFF
--- a/pymdownx/highlight.py
+++ b/pymdownx/highlight.py
@@ -39,6 +39,7 @@ except ImportError:  # pragma: no cover
     pygments = False
     p_ver = (0, 0)
 
+LEXER_CLASS_CACHE = {}
 RE_PYG_CODE = re.compile(r'^<(div)(\s*class="(.*?)")?\s*>')
 CODE_WRAP = '<pre{}><code{}{}{}>{}</code></pre>'
 CODE_WRAP_ON_PRE = '<pre{}{}{}><code>{}</code></pre>'
@@ -281,6 +282,9 @@ class Highlight(object):
 
         if language:
             language, lexer_options = self.get_extended_language(language)
+            cached_lexer_class = LEXER_CLASS_CACHE.get(language)
+            if cached_lexer_class:
+                return cached_lexer_class(**lexer_options), name
         else:
             lexer_options = {}
 
@@ -297,9 +301,15 @@ class Highlight(object):
                     name = lexer.aliases[0]
                 except Exception:  # pragma: no cover
                     pass
+        else:
+            LEXER_CLASS_CACHE[language] = lexer.__class__
+        
         if lexer is None:
             lexer = get_lexer_by_name('text')
             name = lexer.aliases[0]
+            if language:
+                LEXER_CLASS_CACHE[language] = lexer.__class__
+
         return lexer, name
 
     def escape(self, txt):


### PR DESCRIPTION
Hi 👋,
adding this caching method to the script decreased `mkdocs serve` time from ~33* seconds down to ~7 seconds.
My rationale is that the lexer for a given language won't change and shouldn't change during runtime. If someone injects pygment lexers during runtime to change the highlight colour, they could also clear the cache 🤷 

🙋 Please let me know if this is something I should report upstream to Pygments and make them use `functools.lru_cache` for the `get_lexer_by_name` function, but I don't think adding caching to this script is wrong 🤔.

\* - the 33 seconds time is from my current shabby "setup". Old laptop with 2 cores and 2 threads, so this kind of exaggerates the performance gap, but still it's x5 performance gain ✌️  

---

At first I thought, our custom lexer is at fault (not optimized etc.), but removing the lexer module from the site-packages resulted in about the same time (~30 seconds). Setting the `use_pygments` param to `false` resulted in a runtime of ~4 seconds.
After I added the cache, the removal of the lexer module resulted in a runtime of ~5 seconds, so +2 seconds to process all of the code blocks via our custom lexer seems reasonable to me, considering my setup and the amount of documentation pages.

I tested it with our Gothic Modding Community documentation page. [This commit specifically](https://github.com/Gothic-Modding-Community/gmc/tree/1100c33ba44135b2a0210a4cc98010d25225af3f)
Together with a cut down minified `mkdocs.yml`:

<details>

```yml
site_name: Python Extensions Performance Test

watch:
  - overrides

theme:
  name: material
  custom_dir: overrides
  favicon: assets/images/gmc_logo.png
  logo: assets/images/gmc_logo.png

extra_css:
  - assets/stylesheets/extra.css

extra_javascript:
  - assets/javascripts/extra.js

markdown_extensions:
  - admonition
  - pymdownx.highlight:
      use_pygments: true
      linenums: true
      anchor_linenums: true
  - pymdownx.inlinehilite
  - attr_list
  - pymdownx.superfences:
      custom_fences:
        - name: mermaid
          class: mermaid
          format: !!python/name:pymdownx.superfences.fence_code_format
```

</details>

--- 

I also considered adding some sort of caching to the `inlinehilite`, because without testing/profiling, as I understand, it creates a new copy instance of the used highlighter class, each time it highlights inline code. The same rationale applies, the highlighter for a given language shouldn't change during runtime, so there is no need to search for it every time.

I ultimately didn't look into it further as commenting out `pymdownx.inlinehilite` from the `mkdocs.yml` file resulted in similar performance, it decreased the time maybe by ~0.5 seconds, therefore I don't think that adding caching would be as much beneficial 🤷 