### PR TITLE
Fix legacy tabbed failure

### DIFF
--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 10.2.1
+
+-   **FIX**: Tabbed: Fix regression.
+
 ## 10.2
 
 -   **NEW**: Highlight: Add new `stripnl` option to configure Pygments' default handling of stripping leading and

--- a/pymdownx/__meta__.py
+++ b/pymdownx/__meta__.py
@@ -185,5 +185,5 @@ def parse_version(ver, pre=False):
     return Version(major, minor, micro, release, pre, post, dev)
 
 
-__version_info__ = Version(10, 2, 0, "final")
+__version_info__ = Version(10, 2, 1, "final")
 __version__ = __version_info__._get_canonical()

--- a/pymdownx/tabbed.py
+++ b/pymdownx/tabbed.py
@@ -114,7 +114,7 @@ class TabbedProcessor(BlockProcessor):
                     # Handle nested tabbed content
                     if last_child.tag == 'div' and child_class == tabbed_content:
                         temp_child = self.lastChild(last_child)
-                        if temp_child.tag not in ('ul', 'ol', 'dl'):
+                        if temp_child is None or temp_child.tag not in ('ul', 'ol', 'dl'):
                             break
                         last_child = temp_child
                         child_class = last_child.attrib.get('class', '') if last_child is not None else ''

--- a/tests/test_extensions/test_tabbed.py
+++ b/tests/test_extensions/test_tabbed.py
@@ -508,6 +508,27 @@ class TestLegacyTab(util.MdCase):
             True
         )
 
+    def test_indented_code(self):
+        """Test indented code."""
+
+        md = """
+        === "Tab 1"
+
+                code
+        """
+
+        self.check_markdown(
+            md,
+            '''
+            <div class="tabbed-set" data-tabs="1:1"><input checked="checked" id="__tabbed_1_1" name="__tabbed_1" type="radio" /><label for="__tabbed_1_1">Tab 1</label><div class="tabbed-content">
+            <pre><code>code
+            </code></pre>
+            </div>
+            </div>
+            ''',  # noqa: E501
+            True
+        )
+
 
 class TestLegacyTabSlugs(util.MdCase):
     """Test legacy tab slug cases."""
@@ -586,8 +607,7 @@ class TestTabSlugsCombineHeader(util.MdCase):
     extension_configs = {
         'pymdownx.tabbed': {
             'slugify': slugify(case='lower'),
-            'combine_header_slug': True,
-            'alternate_style': True
+            'combine_header_slug': True
         }
     }
 
@@ -611,21 +631,15 @@ class TestTabSlugsCombineHeader(util.MdCase):
             md,
             '''
             <h3 id="here-is-some-text">Here is some text</h3>
-            <div class="tabbed-set tabbed-alternate" data-tabs="1:1"><input checked="checked" id="here-is-some-text-first-tab" name="__tabbed_1" type="radio" /><div class="tabbed-labels"><label for="here-is-some-text-first-tab">First Tab</label></div>
-            <div class="tabbed-content">
-            <div class="tabbed-block">
+            <div class="tabbed-set" data-tabs="1:1"><input checked="checked" id="here-is-some-text-first-tab" name="__tabbed_1" type="radio" /><label for="here-is-some-text-first-tab">First Tab</label><div class="tabbed-content">
             <p>content</p>
-            </div>
             </div>
             </div>
             <h3 id="another-header">Another header</h3>
             <details>
             <summary>title</summary>
-            <div class="tabbed-set tabbed-alternate" data-tabs="2:1"><input checked="checked" id="another-header-second-tab" name="__tabbed_2" type="radio" /><div class="tabbed-labels"><label for="another-header-second-tab">Second Tab</label></div>
-            <div class="tabbed-content">
-            <div class="tabbed-block">
+            <div class="tabbed-set" data-tabs="2:1"><input checked="checked" id="another-header-second-tab" name="__tabbed_2" type="radio" /><label for="another-header-second-tab">Second Tab</label><div class="tabbed-content">
             <p>content</p>
-            </div>
             </div>
             </div>
             </details>
@@ -644,11 +658,8 @@ class TestTabSlugsCombineHeader(util.MdCase):
         self.check_markdown(
             md,
             '''
-            <div class="tabbed-set tabbed-alternate" data-tabs="1:1"><input checked="checked" id="a-tab" name="__tabbed_1" type="radio" /><div class="tabbed-labels"><label for="a-tab">A Tab</label></div>
-            <div class="tabbed-content">
-            <div class="tabbed-block">
+            <div class="tabbed-set" data-tabs="1:1"><input checked="checked" id="a-tab" name="__tabbed_1" type="radio" /><label for="a-tab">A Tab</label><div class="tabbed-content">
             <p>content</p>
-            </div>
             </div>
             </div>
             ''',  # noqa: E501
@@ -668,11 +679,8 @@ class TestTabSlugsCombineHeader(util.MdCase):
         self.check_markdown(
             md,
             '''
-            <div class="tabbed-set tabbed-alternate" data-tabs="1:1"><input checked="checked" id="a-tab" name="__tabbed_1" type="radio" /><div class="tabbed-labels"><label for="a-tab">A Tab</label></div>
-            <div class="tabbed-content">
-            <div class="tabbed-block">
+            <div class="tabbed-set" data-tabs="1:1"><input checked="checked" id="a-tab" name="__tabbed_1" type="radio" /><label for="a-tab">A Tab</label><div class="tabbed-content">
             <p>content</p>
-            </div>
             </div>
             </div>
             <h1 id="header">Header</h1>

--- a/tests/test_extensions/test_tabbed_alternate.py
+++ b/tests/test_extensions/test_tabbed_alternate.py
@@ -562,6 +562,30 @@ class TestTab(util.MdCase):
             True
         )
 
+    def test_indented_code(self):
+        """Test indented code."""
+
+        md = """
+        === "Tab 1"
+
+                code
+        """
+
+        self.check_markdown(
+            md,
+            '''
+            <div class="tabbed-set tabbed-alternate" data-tabs="1:1"><input checked="checked" id="__tabbed_1_1" name="__tabbed_1" type="radio" /><div class="tabbed-labels"><label for="__tabbed_1_1">Tab 1</label></div>
+            <div class="tabbed-content">
+            <div class="tabbed-block">
+            <pre><code>code
+            </code></pre>
+            </div>
+            </div>
+            </div>
+            ''',  # noqa: E501
+            True
+        )
+
 
 class TestLegacyTabSlugs(util.MdCase):
     """Test legacy tab slug cases."""
@@ -636,6 +660,108 @@ class TestLegacyTabSlugsSep(util.MdCase):
             </div>
             </div>
             </div>
+            ''',  # noqa: E501
+            True
+        )
+
+
+class TestTabSlugsCombineHeader(util.MdCase):
+    """Combine header slug with content tab."""
+
+    extension = ['pymdownx.tabbed', 'toc', 'pymdownx.details']
+    extension_configs = {
+        'pymdownx.tabbed': {
+            'slugify': slugify(case='lower'),
+            'combine_header_slug': True,
+            'alternate_style': True
+        }
+    }
+
+    def test_combine_header_slug(self):
+        """Test that slugs are a combination of the header slug and the tab title."""
+
+        md = R"""
+        ### Here is some text
+
+        === "First Tab"
+            content
+
+        ### Another header
+
+        ??? "title"
+            === "Second Tab"
+                content
+        """
+
+        self.check_markdown(
+            md,
+            '''
+            <h3 id="here-is-some-text">Here is some text</h3>
+            <div class="tabbed-set tabbed-alternate" data-tabs="1:1"><input checked="checked" id="here-is-some-text-first-tab" name="__tabbed_1" type="radio" /><div class="tabbed-labels"><label for="here-is-some-text-first-tab">First Tab</label></div>
+            <div class="tabbed-content">
+            <div class="tabbed-block">
+            <p>content</p>
+            </div>
+            </div>
+            </div>
+            <h3 id="another-header">Another header</h3>
+            <details>
+            <summary>title</summary>
+            <div class="tabbed-set tabbed-alternate" data-tabs="2:1"><input checked="checked" id="another-header-second-tab" name="__tabbed_2" type="radio" /><div class="tabbed-labels"><label for="another-header-second-tab">Second Tab</label></div>
+            <div class="tabbed-content">
+            <div class="tabbed-block">
+            <p>content</p>
+            </div>
+            </div>
+            </div>
+            </details>
+            ''',  # noqa: E501
+            True
+        )
+
+    def test_no_header(self):
+        """Test when there is no header."""
+
+        md = R"""
+        === "A Tab"
+            content
+        """
+
+        self.check_markdown(
+            md,
+            '''
+            <div class="tabbed-set tabbed-alternate" data-tabs="1:1"><input checked="checked" id="a-tab" name="__tabbed_1" type="radio" /><div class="tabbed-labels"><label for="a-tab">A Tab</label></div>
+            <div class="tabbed-content">
+            <div class="tabbed-block">
+            <p>content</p>
+            </div>
+            </div>
+            </div>
+            ''',  # noqa: E501
+            True
+        )
+
+    def test_header_after(self):
+        """Test when header comes after."""
+
+        md = R"""
+        === "A Tab"
+            content
+
+        # Header
+        """
+
+        self.check_markdown(
+            md,
+            '''
+            <div class="tabbed-set tabbed-alternate" data-tabs="1:1"><input checked="checked" id="a-tab" name="__tabbed_1" type="radio" /><div class="tabbed-labels"><label for="a-tab">A Tab</label></div>
+            <div class="tabbed-content">
+            <div class="tabbed-block">
+            <p>content</p>
+            </div>
+            </div>
+            </div>
+            <h1 id="header">Header</h1>
             ''',  # noqa: E501
             True
         )


### PR DESCRIPTION
Additionally, ensure that new header slug tests are performed in both alternate style and non-alternate style.

Fixes #2158 