### PR TITLE
Add note about using replacement block plugins

### DIFF
--- a/docs/src/markdown/extensions/blocks/plugins/admonition.md
+++ b/docs/src/markdown/extensions/blocks/plugins/admonition.md
@@ -2,6 +2,14 @@
 
 # Admonition
 
+/// danger | Using `pymdownx.blocks.admonition` with `admonition`
+The new `pymdownx.blocks.admonition` extension is meant to replace `admonition`, they are not meant to be used together.
+Their output is identical making it easy to transition by simply swapping out the syntax, but using them both together
+can cause issues as they both generate the same output and confuse each other.
+
+If you are switching from `admonition` to `pymdownx.blocks.admonition`, ensure you disable `admonition` to avoid issues.
+///
+
 --8<-- "blocksbeta.md"
 
 ## Overview

--- a/docs/src/markdown/extensions/blocks/plugins/definition.md
+++ b/docs/src/markdown/extensions/blocks/plugins/definition.md
@@ -2,6 +2,14 @@
 
 # Definition
 
+/// danger | Using `pymdownx.blocks.definition` with `def_list`
+The new `pymdownx.blocks.definition` extension is meant to replace `def_list`, they are not meant to be used together.
+Their output is identical making it easy to transition by simply swapping out the syntax, but using them both together
+can cause issues as they both generate the same output and confuse each other.
+
+If you are switching from `def_list` to `pymdownx.blocks.definition`, ensure you disable `def_list` to avoid issues.
+///
+
 --8<-- "blocksbeta.md"
 
 ## Overview

--- a/docs/src/markdown/extensions/blocks/plugins/details.md
+++ b/docs/src/markdown/extensions/blocks/plugins/details.md
@@ -1,6 +1,15 @@
 [:octicons-file-code-24:][_details_block]{: .source-link }
 # Details
 
+/// danger | Using `pymdownx.blocks.details` with `pymdownx.details`
+The new `pymdownx.blocks.details` extension is meant to replace `pymdownx.details`, they are not meant to be used
+together. Their output is identical making it easy to transition by simply swapping out the syntax, but using them both
+together can cause issues as they both generate the same output and confuse each other.
+
+If you are switching from `pymdownx.details` to `pymdownx.blocks.details`, ensure you disable `pymdownx.details` to
+avoid issues.
+///
+
 --8<-- "blocksbeta.md"
 
 ## Overview

--- a/docs/src/markdown/extensions/blocks/plugins/tab.md
+++ b/docs/src/markdown/extensions/blocks/plugins/tab.md
@@ -2,6 +2,15 @@
 
 # Tab
 
+/// danger | Using `pymdownx.blocks.tab` with `pymdownx.tabbed`
+The new `pymdownx.blocks.tab` extension is meant to replace `pymdownx.tabbed`, they are not meant to be used together.
+Their output is identical making it easy to transition by simply swapping out the syntax, but using them both together
+can cause issues as they both generate the same output and confuse each other.
+
+If you are switching from `pymdownx.tabbed` to `pymdownx.blocks.tab`, ensure you disable `pymdownx.tabbed` to avoid
+issues.
+///
+
 --8<-- "blocksbeta.md"
 
 ## Overview


### PR DESCRIPTION
When using the block plugins that are meant to replace others (Tab, Admonition, Details, and Definition), it should be clearly stated that you must replace usage of these, not pair them together with what they are replacing.

Closes #2173