### PR TITLE
Fixing tabbed-set label placement for cases where alternative renderers keep the HTML element order

### DIFF
--- a/docs/src/scss/extensions/_tabbed.scss
+++ b/docs/src/scss/extensions/_tabbed.scss
@@ -64,6 +64,22 @@
         }
       }
     }
+    &.tabbed-set > .tabbed-labels {
+      @media print {
+        display: none;
+      }
+    }
+    &.tabbed-set .tabbed-label-print > label {
+      @extend .tabbed-labels;
+      @media print {
+        display: block;
+      }
+    }
+  }
+}
+.tabbed-label-print > label {
+  @media screen {
+    display: none;
   }
 }
 

--- a/pymdownx/tabbed.py
+++ b/pymdownx/tabbed.py
@@ -177,6 +177,15 @@ class TabbedProcessor(BlockProcessor):
             labels = None
             content = None
 
+            if self.alternate_style:
+                # Add labels to the top of each content block
+                print_label_div = etree.Element('div', {'class': 'tabbed-label-print', 'hidden':''})
+                print_label_label = etree.SubElement(print_label_div, 'label')
+                print_label_label.text = title
+
+                # Prepend the print_label_div to the block
+                block = etree.tostring(print_label_div, encoding='unicode') + block
+
             if (
                 sibling is not None and sibling.tag.lower() == 'div' and
                 sibling.attrib.get('class', '') == tabbed_set and

--- a/pymdownx/tabbed.py
+++ b/pymdownx/tabbed.py
@@ -48,7 +48,10 @@ class TabbedProcessor(BlockProcessor):
         self.current_sibling = None
         self.content_indention = 0
         self.alternate_style = config['alternate_style']
+        self.alternate_style_for_pdf = config['alternate_style_for_pdf']
         self.slugify = callable(config['slugify'])
+        if self.alternate_style_for_pdf:
+            self.alternate_style = self.alternate_style_for_pdf
 
     def detab_by_length(self, text, length):
         """Remove a tab from the front of each line of the given text."""
@@ -177,7 +180,7 @@ class TabbedProcessor(BlockProcessor):
             labels = None
             content = None
 
-            if self.alternate_style:
+            if self.alternate_style_for_pdf:
                 # Add labels to the top of each content block
                 print_label_div = etree.Element('div', {'class': 'tabbed-label-print', 'hidden':''})
                 print_label_label = etree.SubElement(print_label_div, 'label')
@@ -406,6 +409,7 @@ class TabbedExtension(Extension):
 
         self.config = {
             'alternate_style': [False, "Use alternate style - Default: False"],
+            'alternate_style_for_pdf': [False, "Use alternate style with additional elements for exporting to PDF - Default: False"],
             'slugify': [0, "Slugify function used to create tab specific IDs - Default: None"],
             'combine_header_slug': [False, "Combine the tab slug with the slug of the parent header - Default: False"],
             'separator': ['-', "Slug separator - Default: '-'"]


### PR DESCRIPTION
Adding hidden alt-style tabbed-set labels to the top of tabbed-blocks

- Replicating the structure of `.tabbed-labels` to make replicating that CSS easier.
- Using the `hidden` attribute on the new label's div wrapper because so it can easily be overridden by CSS and doesn't alter the existing appearance.
- Apparently `aria-hidden: false` doesn't counteract `display: none` for AT, so I didn't add that. Such would likely need to be another, separate solution.

Scenario:
I'm working with Material for MkDocs using the alternate tabbed style. I also use [domWalter's continuation of the mkdocs-with-pdf](https://github.com/domWalters/mkdocs-to-pdf) plugin using RelaxedJS.  When exporting to PDF, tabbed-sets would print all the tab labels at the top followed by the tabbed-contents, just like it is in HTML despite the web browser's print view showing differently. So this is my fix for this - essentially creating something closer to the standard tabbed style for use only with `@media print`.