### PR TITLE
fix: allow `SmartAsteriskProcessor` support inline bold and italic which are without spaces

### DIFF
--- a/pymdownx/betterem.py
+++ b/pymdownx/betterem.py
@@ -86,21 +86,21 @@ SMART_UNDER_EM2 = r'(?<![\w_])(_)(?![_\s])(.+?)(?<![_\s])(_)(?![_\w])'
 
 # Smart rules for when "smart asterisk" is enabled
 # SMART: ***strong,em***
-SMART_STAR_STRONG_EM = r'(?:(?<=_)|(?<![\w\*]))(\*{3})(?![\s\*])%s(?<!\s)\1(?:(?=_)|(?![\w\*]))' % SMART_STAR_CONTENT
+SMART_STAR_STRONG_EM = r'(?:(?<=\w)|(?<![\w\*]))(\*{3})(?![\s\*])%s(?<!\s)\1(?:(?=\w)|(?![\w\*]))' % SMART_STAR_CONTENT
 # ***strong,em* strong**
 SMART_STAR_STRONG_EM2 = \
-    r'(?:(?<=_)|(?<![\w\*]))(\*{{3}})(?![\s\*]){}(?<!\s)\*(?:(?=_)|(?![\w\*])){}(?<!\s)\*{{2}}(?:(?=_)|(?![\w\*]))'.format(
+    r'(?:(?<=\w)|(?<![\w\*]))(\*{{3}})(?![\s\*]){}(?<!\s)\*(?:(?=_)|(?![\w\*])){}(?<!\s)\*{{2}}(?:(?=\w)|(?![\w\*]))'.format(
         SMART_STAR_CONTENT, SMART_STAR_CONTENT
     )
 # ***em,strong** em*
 SMART_STAR_EM_STRONG = \
-    r'(?:(?<=_)|(?<![\w\*]))(\*{{3}})(?![\s\*]){}(?<!\s)\*{{2}}(?:(?=_)|(?![\w\*])){}(?<!\s)\*(?:(?=_)|(?![\w\*]))'.format(
+    r'(?:(?<=\w)|(?<![\w\*]))(\*{{3}})(?![\s\*]){}(?<!\s)\*{{2}}(?:(?=_)|(?![\w\*])){}(?<!\s)\*(?:(?=\w)|(?![\w\*]))'.format(
         SMART_STAR_CONTENT, SMART_STAR_CONTENT
     )
 # **strong**
-SMART_STAR_STRONG = r'(?:(?<=_)|(?<![\w\*]))(\*{2})(?![\s\*])%s(?<!\s)\1(?:(?=_)|(?![\w\*]))' % SMART_STAR_CONTENT
+SMART_STAR_STRONG = r'(?:(?<=\w)|(?<![\w\*]))(\*{2})(?![\s\*])%s(?<!\s)\1(?:(?=\w)|(?![\w\*]))' % SMART_STAR_CONTENT
 # SMART *em*
-SMART_STAR_EM = r'(?:(?<=_)|(?<![\w\*]))(\*)(?![\s\*])%s(?<!\s)\1(?:(?=_)|(?![\w\*]))' % SMART_STAR_CONTENT
+SMART_STAR_EM = r'(?:(?<=\w)|(?<![\w\*]))(\*)(?![\s\*])%s(?<!\s)\1(?:(?=\w)|(?![\w\*]))' % SMART_STAR_CONTENT
 # Prioritize *value* when **value** is nested within
 SMART_STAR_EM2 = r'(?<![\w\*])(\*)(?![\*\s])(.+?)(?<![\*\s])(\*)(?![\*\w])'
 

--- a/tests/test_extensions/test_betterem.py
+++ b/tests/test_extensions/test_betterem.py
@@ -81,3 +81,64 @@ class TestBetterSmartAll(util.MdCase):
             ''',
             True
         )
+
+class TestBetterSmartEnableAll(util.MdCase):
+    """Test specific cases for BetterEm with smart_enable: 'all'."""
+
+    extension = [
+        'pymdownx.betterem'
+    ]
+    extension_configs = {
+        "pymdownx.betterem": {
+            "smart_enable": "all"
+        }
+    }
+
+    def test_bold_no_spaces(self):
+        """Test bold with no spaces around the asterisks."""
+
+        self.check_markdown(
+            'test**foo**test',
+            '<p>test<strong>foo</strong>test</p>'
+        )
+
+
+    def test_bold_with_spaces(self):
+        """Test bold with spaces around the asterisks."""
+
+        self.check_markdown(
+            'test **foo** test',
+            '<p>test <strong>foo</strong> test</p>'
+        )
+
+    def test_bold_with_special_characters(self):
+        """Test bold with special characters nearby."""
+
+        self.check_markdown(
+            'test**foo!**bar',
+            '<p>test<strong>foo!</strong>bar</p>'
+        )
+
+    def test_italic_no_spaces(self):
+        """Test italic with no spaces around the asterisks."""
+
+        self.check_markdown(
+            'test*foo*test',
+            '<p>test<em>foo</em>test</p>'
+        )
+
+    def test_italic_with_spaces(self):
+        """Test italic with spaces around the asterisks."""
+
+        self.check_markdown(
+            'test *foo* test',
+            '<p>test <em>foo</em> test</p>'
+        )
+
+    def test_italic_with_special_characters(self):
+        """Test italic with special characters nearby."""
+
+        self.check_markdown(
+            'test*foo!*bar',
+            '<p>test<em>foo!</em>bar</p>'
+        )

--- a/tests/test_extensions/test_betterem.py
+++ b/tests/test_extensions/test_betterem.py
@@ -82,18 +82,6 @@ class TestBetterSmartAll(util.MdCase):
             True
         )
 
-class TestBetterSmartEnableAll(util.MdCase):
-    """Test specific cases for BetterEm with smart_enable: 'all'."""
-
-    extension = [
-        'pymdownx.betterem'
-    ]
-    extension_configs = {
-        "pymdownx.betterem": {
-            "smart_enable": "all"
-        }
-    }
-
     def test_bold_no_spaces(self):
         """Test bold with no spaces around the asterisks."""
 
@@ -101,7 +89,6 @@ class TestBetterSmartEnableAll(util.MdCase):
             'test**foo**test',
             '<p>test<strong>foo</strong>test</p>'
         )
-
 
     def test_bold_with_spaces(self):
         """Test bold with spaces around the asterisks."""


### PR DESCRIPTION
Markdown allows the use of bold and italic without spaces. This expression causes a problem when it is used in without space case.
<img width="375" alt="截屏2024-09-08 01 27 02" src="https://github.com/user-attachments/assets/c33804e9-bbab-4993-9201-58672579372c">

Some languages never require whitespace between words or phrases, like Chinese and Japanese.  

For example:

Correct case:  
<img width="574" alt="截屏2024-09-08 01 19 53" src="https://github.com/user-attachments/assets/8f78dcf4-c735-4348-9c6e-05165e4863da">
<img width="669" alt="截屏2024-09-08 01 28 39" src="https://github.com/user-attachments/assets/6356a5fb-74da-480b-a161-caadb0cfadea">

Actual result in some docs:
<img width="541" alt="截屏2024-09-08 01 25 52" src="https://github.com/user-attachments/assets/fef7b63c-72e7-458b-8541-1b0139132a58">
<img width="749" alt="截屏2024-09-08 01 26 15" src="https://github.com/user-attachments/assets/982ff033-3f6d-4e09-b4e7-3006974fc402">

