### PR TITLE
fix: Allow for pandoc style codefences

### DIFF
--- a/pymdownx/superfences.py
+++ b/pymdownx/superfences.py
@@ -51,7 +51,7 @@ RE_NESTED_FENCE_START = re.compile(
                 (?:\b[a-zA-Z][a-zA-Z0-9_]*(?:=(?P<quot>"|').*?(?P=quot))?[ \t]*) |  # Options
             )*
         )
-    )[ \t]*$
+    )+[ \t]*$
     '''
 )
 


### PR DESCRIPTION
Great extension! Love its ubiquity. Noticed that the codefence logic does not match something like:

````md
```haskell {.numberLines}
qsort [] = []
```
````

(see https://regex101.com/r/luUSyy/1)

Which is acceptable and expected in pandoc: https://pandoc.org/chunkedhtml-demo/8.5-verbatim-code-blocks.html#extension-fenced_code_attributes

`+` fixes this and allows for a bit more flexibility in the attribute ordering: https://regex101.com/r/jEZuZ7/1