### PR TITLE
Block caption extension: Added tests for default configuration and `autoid`

### DIFF
--- a/pymdownx/fancylists.py
+++ b/pymdownx/fancylists.py
@@ -215,7 +215,7 @@ class FancyOListProcessor(BlockProcessor):
                     if self.inject_style:
                         attrib['style'] = f"list-style-type: {OL_STYLE[attrib['type']]};"
                     if self.inject_class:
-                        attrib['class'] = f"fancylists-{OL_STYLE[attrib['type']]};"
+                        attrib['class'] = f"fancylists-{OL_STYLE[attrib['type']]}"
                     lst = etree.SubElement(
                         parent,
                         self.TAG,
@@ -454,7 +454,7 @@ class FancyListBlock(Block):
         if self.inject_style:
             attrib['style'] = f"list-style-type: {OL_STYLE[self.type]};"
         if self.inject_class:
-            attrib['class'] = f"fancylists-{OL_STYLE[self.type]};"
+            attrib['class'] = f"fancylists-{OL_STYLE[self.type]}"
 
         self.parent = parent
         self.ol = etree.SubElement(parent, 'ol', attrib)

--- a/tests/test_extensions/test_fancylists.py
+++ b/tests/test_extensions/test_fancylists.py
@@ -1030,7 +1030,7 @@ class TestFancyListsClass(util.MdCase):
             i. Item i
             ''',
             R'''
-            <ol class="fancylists-lower-roman;" type="i">
+            <ol class="fancylists-lower-roman" type="i">
             <li>Item i</li>
             </ol>
             ''',
@@ -1047,7 +1047,7 @@ class TestFancyListsClass(util.MdCase):
             ///
             ''',
             R'''
-            <ol class="fancylists-lower-roman;" start="5" type="i">
+            <ol class="fancylists-lower-roman" start="5" type="i">
             <li>Item v</li>
             </ol>
             ''',


### PR DESCRIPTION
I've added tests for using the caption block extension with no configuration and `autoid` enabled.

The last test fails, when two captions with nested captions are present.