### PR TITLE
Correctly document StripHTML defaults

### DIFF
--- a/docs/src/markdown/extensions/striphtml.md
+++ b/docs/src/markdown/extensions/striphtml.md
@@ -39,7 +39,7 @@ md = markdown.Markdown(extensions=['pymdownx.striphtml'])
 
 ## Options
 
-By default, StripHTML strips the following attributes: `style`, `id`, `class`, and `on<name>`.  StripHTML also strips
+By default, StripHTML only strips attributes starting with `on` (for instance `onclick`).  StripHTML also strips
 HTML comments. If desired, its behavior can be configured to strip less or even more, but it is limited to attributes
 and comments.
 


### PR DESCRIPTION
The documentation of default settings in the main text is outdated, and is not in line with the behavior of the `StripHTML` extension. This commit fixes the documentation.