### PR TITLE
Update changelog and support GH releases on CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,3 +53,22 @@ jobs:
         with:
           user: __token__
           password: ${{ secrets.PYPI_TOKEN }}
+
+  gh-release:
+    runs-on: ubuntu-latest
+    needs:
+      - documents
+      - pypi
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Extract release notes
+        uses: ffurrer2/extract-release-notes@v2
+        with:
+          changelog_file: docs/src/markdown/about/changelog.md
+          release_notes_file: RELEASE_NOTES.md
+      - name: Create release
+        run: gh release create ${{ github.ref_name }} --notes-file RELEASE_NOTES.md
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -1,25 +1,25 @@
 # Changelog
 
-## 10.14.3
+## [10.14.3](https://github.com/facelessuser/pymdown-extensions/releases/tag/10.14.3)
 
 -   **FIX**: Blocks: An empty, raw block type should not cause an error.
 
-## 10.14.2
+## [10.14.2](https://github.com/facelessuser/pymdown-extensions/releases/tag/10.14.2)
 
 -   **FIX**: Blocks: Fix some corner cases with `md_in_html`.
 
-## 10.14.1
+## [10.14.1](https://github.com/facelessuser/pymdown-extensions/releases/tag/10.14.1)
 
 -   **FIX**: MagicLink: Ensure that repo names that start with `.` are handled correctly.
 -   **FIX**: FancyLists: Fix case were lists could be falsely created when a line started with `.` or `)`.
 
-## 10.14
+## [10.14](https://github.com/facelessuser/pymdown-extensions/releases/tag/10.14)
 
 -   **NEW**: Blocks.HTML: Add new `custom` option to specify tags and the assumed handling for them when automatic mode
     is assumed. This can also be used to override the handling for recognized tags with automatic handling.
 -   **FIX**: Fix tests to pass with Pygments 2.19+.
 
-## 10.13
+## [10.13](https://github.com/facelessuser/pymdown-extensions/releases/tag/10.13)
 
 -   **NEW**: Snippets: Allow multiple line numbers or line number blocks separated by `,`.
 -   **NEW**: Snippets: Allow using a negative index for number start indexes and end indexes. Negative indexes are
@@ -29,7 +29,7 @@
 -   **FIX**: BetterEm: Fixes for complex cases.
 -   **FIX**: Blocks: More consistent handling of empty newlines in block processor extensions.
 
-## 10.12
+## [10.12](https://github.com/facelessuser/pymdown-extensions/releases/tag/10.12)
 
 -   **NEW**: Blocks: Blocks extensions no longer considered in beta.
 -   **NEW**: Details: Details is marked as "legacy" in documentation in favor of the new `pymdownx.blocks.details` approach.
@@ -39,30 +39,30 @@
     removed, or never existed.
 -   **FIX**: Emoji: Emoji links should be generated such that they point to the new CDN version.
 
-## 10.11.2
+## [10.11.2](https://github.com/facelessuser/pymdown-extensions/releases/tag/10.11.2)
 
 -   **FIX**: SuperFences: Fix a regression where certain patterns could cause a hang.
 
-## 10.11.1
+## [10.11.1](https://github.com/facelessuser/pymdown-extensions/releases/tag/10.11.1)
 
 -   **Fix**: SuperFences: Fix regression where an omitted language in conjunction with options in the fenced header
     can cause a fence to not be parsed.
 
-## 10.11
+## [10.11](https://github.com/facelessuser/pymdown-extensions/releases/tag/10.11)
 
 -   **NEW**: SuperFences: Allow fenced code to be parsed in the form ` ```lang {.class #id} `.
 
-## 10.10.2
+## [10.10.2](https://github.com/facelessuser/pymdown-extensions/releases/tag/10.10.2)
 
 -   **FIX**: BetterEm: Add better support for `*em, **em,strong***` and `_em, __em,strong___` cases.
 -   **FIX**: Caret: Add better support for `*sup, **sup,ins***`.
 -   **FIX**: Tilde: Add better support for `*sub, **sub,del***`.
 
-## 10.10.1
+## [10.10.1](https://github.com/facelessuser/pymdown-extensions/releases/tag/10.10.1)
 
 -   **FIX**: FancyLists: Remove a mistaken semicolon from injected classes.
 
-## 10.10
+## [10.10](https://github.com/facelessuser/pymdown-extensions/releases/tag/10.10)
 
 -   **NEW**: FancyLists: Add new FancyLists extension.
 -   **NEW**: MagicLink: Change social links to support `x` instead of `twitter`. `twitter` is still recognized but is
@@ -70,26 +70,26 @@
 -   **NEW**: Emoji: Update Twemoji data to the latest.
 -   **FIX**: PathConverter: Fixes for latest changes in Python regarding `urlunparse`.
 
-## 10.9
+## [10.9](https://github.com/facelessuser/pymdown-extensions/releases/tag/10.9)
 
 -   **NEW**: Officially support Python 3.13.
 -   **FIX**: Snippets: Better handling of cases where URL snippet requests contain no header length.
 
-## 10.8.1
+## [10.8.1](https://github.com/facelessuser/pymdown-extensions/releases/tag/10.8.1)
 
 -   **FIX**: Snippets: Fix snippet line range with a start of line 1.
 
-## 10.8
+## [10.8](https://github.com/facelessuser/pymdown-extensions/releases/tag/10.8)
 
 -   **NEW**: Require Python Markdown 3.6+.
 -   **FIX**: Fix some test cases.
 -   **FIX**: Fix warnings due to recent changes in Python Markdown.
 
-## 10.7.1
+## [10.7.1](https://github.com/facelessuser/pymdown-extensions/releases/tag/10.7.1)
 
 -   **FIX**: SmartSymbols: Ensure symbols are properly translated in table of content tokens.
 
-## 10.7
+## [10.7](https://github.com/facelessuser/pymdown-extensions/releases/tag/10.7)
 
 -   **NEW**: Emoji: Update Twemoji and Gemoji data to latest.
 -   **NEW**: Emoji: Due to recent Gemoji update, non-standard emoji are no longer indexed. So emoji such as `:octocat:`
@@ -101,63 +101,63 @@
     boolean requirement) to treat inline code blocks with no explicit language specifier with a specific default
     language.
 
-## 10.6
+## [10.6](https://github.com/facelessuser/pymdown-extensions/releases/tag/10.6)
 
 -   **NEW**: MagicLink: Allow configuring custom repository providers based off the existing providers.
 
-## 10.5
+## [10.5](https://github.com/facelessuser/pymdown-extensions/releases/tag/10.5)
 
 -   **NEW**: Blocks: Admonitions and Details now allow configuring custom block classes and default titles.
 -   **FIX**: Keys: Ensure that Keys does not parse base64 encoded URLs.
 
-## 10.4
+## [10.4](https://github.com/facelessuser/pymdown-extensions/releases/tag/10.4)
 
 -   **NEW**: Snippets: Allow PathLike objects for `base_path` to better support interactions with MkDocs.
 -   **FIX**: Block Admonitions: Empty titles should be respected.
 -   **FIX**: Block Details: Empty summary should be respected.
 
-## 10.3.1
+## [10.3.1](https://github.com/facelessuser/pymdown-extensions/releases/tag/10.3.1)
 
 -   **FIX**: SuperFences: Fix an issue where braces were not handled properly in attributes.
 
-## 10.3
+## [10.3](https://github.com/facelessuser/pymdown-extensions/releases/tag/10.3)
 
 -   **NEW**: Officially support Python 3.12.
 -   **NEW**: Drop Python 3.7 support.
 
-## 10.2.1
+## [10.2.1](https://github.com/facelessuser/pymdown-extensions/releases/tag/10.2.1)
 
 -   **FIX**: Tabbed: Fix regression.
 
-## 10.2
+## [10.2](https://github.com/facelessuser/pymdown-extensions/releases/tag/10.2)
 
 -   **NEW**: Highlight: Add new `stripnl` option to configure Pygments' default handling of stripping leading
     and trailing new lines from code blocks. Mainly affects fenced code blocks.
 -   **FIX**: SuperFences: Fix issue where when SuperFences attempts to test if a placeholder is its own, it can throw
     an exception.
 
-## 10.1
+## [10.1](https://github.com/facelessuser/pymdown-extensions/releases/tag/10.1)
 
 -   **NEW**: Add new `combine_header_slug` option in legacy Tabbed extension and new Block Tab extension that will
     prefix a content tab's slug with the parent header's slug. This allows for content tab slugs that are scoped to the
     header they are under.
 
-## 10.0.1
+## [10.0.1](https://github.com/facelessuser/pymdown-extensions/releases/tag/10.0.1)
 
 -   **FIX**: Regression related to snippets nested deeply under specified base path.
 
-## 10.0
+## [10.0](https://github.com/facelessuser/pymdown-extensions/releases/tag/10.0)
 
 -   **Break**: Snippets: snippets will restrict snippets to ensure they are under the `base_path` preventing snippets
     relative to the `base_path` but not explicitly under it. `restrict_base_path` can be set to `False` for legacy
     behavior.
 
-## 9.11
+## [9.11](https://github.com/facelessuser/pymdown-extensions/releases/tag/9.11)
 
 -   **NEW**: Emoji: Update to new CDN and use Twemoji 14.1.2.
 -   **NEW**: Snippets: Ignore nested snippet section syntax when including a section.
 
-## 9.10
+## [9.10](https://github.com/facelessuser/pymdown-extensions/releases/tag/9.10)
 
 -   **NEW**: Blocks: Add new experimental general purpose blocks that provide a framework for creating fenced block
     containers for specialized parsing. A number of extensions utilizing general purpose blocks are included and are
@@ -172,21 +172,21 @@
 -   **NEW**: MagicLink: Update GitLab links to match recent changes and to be more correct.
 -   **NEW**: MagicLink: Relax required hash length when performing link shortening.
 
-## 9.9.3
+## [9.9.3](https://github.com/facelessuser/pymdown-extensions/releases/tag/9.9.3)
 
 -   **FIX**: Highlight: Remove extraneous new lines from end of indented code blocks when using
     `#!py use_pygments = False`.
 
-## 9.9.2
+## [9.9.2](https://github.com/facelessuser/pymdown-extensions/releases/tag/9.9.2)
 
 -   **FIX**: Snippets syntax can break in XML comments as XML comments do not allow `--`. Relax Snippets syntax such
     that `-8<-` (single `-`) are allowed.
 
-## 9.9.1
+## [9.9.1](https://github.com/facelessuser/pymdown-extensions/releases/tag/9.9.1)
 
 -   **FIX**: Use a different CDN for Twemoji icons as MaxCDN is no longer available.
 
-## 9.9
+## [9.9](https://github.com/facelessuser/pymdown-extensions/releases/tag/9.9)
 
 -   **ENHANCE**: BetterEm: Further improvements to strong/emphasis handling:
     -   Ensure that one or more consecutive `*` or `_` surrounded by whitespace are not considered as a token.
@@ -199,18 +199,18 @@
 -   **ENHANCE**: Mark: Apply recent BetterEm improvements to Mark:
     -   Ensure that one or more consecutive `=` surrounded by whitespace are not considered a token.
 
-## 9.8
+## [9.8](https://github.com/facelessuser/pymdown-extensions/releases/tag/9.8)
 
 -   **NEW**: Formally declare support for Python 3.11.
 -   **FIX**: BetterEm: Fix case where `**` nested between `*` would be handled in an unexpected way.
 
-## 9.7
+## [9.7](https://github.com/facelessuser/pymdown-extensions/releases/tag/9.7)
 
 -   **NEW**: Tabbed: Add new syntax to allow forcing a specific tab to be select by default.
 -   **NEW**: Snippets: Add new option to pass arbitrary HTTP headers.
 -   **NEW**: Snippets: Allow specifying sections in a snippet and including just the specified section.
 
-## 9.6
+## [9.6](https://github.com/facelessuser/pymdown-extensions/releases/tag/9.6)
 
 -   **NEW**: Highlight: Allow greater granularity of specifying where language guessing takes place via `guess_lang`
     option (e.g. `block` vs `inline`).
@@ -219,7 +219,7 @@
 -   **NEW**: Snippets: Commenting out files in block format no longer requires a space directly after `;`.
 -   **NEW**: Snippets: A new sane way to escape snippets is now available.
 
-## 9.5
+## [9.5](https://github.com/facelessuser/pymdown-extensions/releases/tag/9.5)
 
 -   **NEW**: InlineHilite: Custom inline code block formatters can now be forced to raise an exception by raising a
     `InlineHiliteException`.
@@ -229,18 +229,18 @@
 -   **NEW**: Snippets: When a file or URL is missing, raise `SnippetMissingError` instead of `IOError`.
 -   **FIX**: Snippets: Small issues related to recursive inclusion of snippets.
 
-## 9.4
+## [9.4](https://github.com/facelessuser/pymdown-extensions/releases/tag/9.4)
 
 -   **NEW**: Highlight: Changes in order to support Pygments 2.12+. If using Pygments and a version less than 2.12 is
     installed, Highlight will raise an exception.
 
-## 9.3
+## [9.3](https://github.com/facelessuser/pymdown-extensions/releases/tag/9.3)
 
 -   **NEW**: B64: Allow SVG to be encoded and inlined.
 -   **NEW**: PathConverter: Add option to use `file://` prefix on absolute paths.
 -   **FIX**: Highlight: Ensure that `extend_pygments_lang` is not case sensitive regarding language names.
 
-## 9.2
+## [9.2](https://github.com/facelessuser/pymdown-extensions/releases/tag/9.2)
 
 -   **NEW**: Drop Python 3.6 support and formally add Python 3.10 support.
 -   **NEW**: Highlight: Add `pygments_lang_option` to enable attaching language classes to Pygments code blocks.
@@ -251,7 +251,7 @@
 -   **FIX**: Arithmatex: fix issue where if you limit the inline or block syntax to specific input types, access to
     certain matched groups could cause an error.
 
-## 9.1
+## [9.1](https://github.com/facelessuser/pymdown-extensions/releases/tag/9.1)
 
 -   **NEW**: Highlight: If `linenums` is enabled globally via the `highlight` extension, and a code block specifies a
     line number of zero (e.g. SuperFences), disable line numbers for that code block.
@@ -259,7 +259,7 @@
 -   **FIX**: Highlight: When `attr_list` is enabled, attributes were not properly added to Pygments code blocks in the
     `table` format. (#1505)
 
-## 9.0
+## [9.0](https://github.com/facelessuser/pymdown-extensions/releases/tag/9.0)
 
 Please see [Migration Notes](./releases/9.0.md) for details on upgrading to 9.0.
 
@@ -298,7 +298,7 @@ Please see [Migration Notes](./releases/9.0.md) for details on upgrading to 9.0.
 -   **FIX**: Highlight: Fix issue that occurs when showing only nth line numbers and using `pymdownx-inline`. Lines not
     showing a line number would not render with the proper leading space.
 
-## 8.2
+## [8.2](https://github.com/facelessuser/pymdown-extensions/releases/tag/8.2)
 
 -   **NEW**: Snippets: now accepts a list of base paths which will be resolved in the order they are specified.
     Compatibility is present with legacy behavior, and a single string path will still be accepted.
@@ -317,12 +317,12 @@ Please see [Migration Notes](./releases/9.0.md) for details on upgrading to 9.0.
 -   **FIX**: Tabbed &amp; Details: Fix corner case with lists. (#1225)
 -   **FIX**: Fix issue with unescaping logic in code blocks.
 
-## 8.1.1
+## [8.1.1](https://github.com/facelessuser/pymdown-extensions/releases/tag/8.1.1)
 
 -   **FIX**: Ensure content immediately before Details content or Tabbed content gets preserved.
 -   **FIX**: StripHTML: Fix some corner cases related to stripping comments.
 
-## 8.1
+## [8.1](https://github.com/facelessuser/pymdown-extensions/releases/tag/8.1)
 
 -   **NEW**: Drop support for Python 3.5.
 -   **NEW**: Officially support Python 3.9.
@@ -330,11 +330,11 @@ Please see [Migration Notes](./releases/9.0.md) for details on upgrading to 9.0.
     etc.).
 -   **FIX**: Avoid parsing script tags in PathConverter and B64 extensions.
 
-## 8.0.1
+## [8.0.1](https://github.com/facelessuser/pymdown-extensions/releases/tag/8.0.1)
 
 -   **FIX**: Fix issue with `pymdownx-inline` an Pygments 2.7+.
 
-## 8.0
+## [8.0](https://github.com/facelessuser/pymdown-extensions/releases/tag/8.0)
 
 Please see [Migration Notes](./releases/8.0.md) for details on upgrading to 8.0.
 
@@ -371,7 +371,7 @@ Please see [Migration Notes](./releases/8.0.md) for details on upgrading to 8.0.
 -   **FIX**: EscapeAll: Handle HTML entities special.
 -   **FIX**: SuperFences: Fix parameter unpacking bug.
 
-## 7.1
+## [7.1](https://github.com/facelessuser/pymdown-extensions/releases/tag/7.1)
 
 -   **NEW**: SuperFences will now allow number ranges in `hl_lines` option. (#878)
 -   **NEW**: Emoji extension now requires custom emoji indexes to take an `options` and `md` argument. The old
@@ -381,7 +381,7 @@ Please see [Migration Notes](./releases/8.0.md) for details on upgrading to 8.0.
 -   **FIX**: Better Arithmatex patterns. Fix issue #888 which caused a hang due to a regular expression typo. Also
     ensure `#!tex $$..$$` and `#!tex begin{}...end{}` patterns properly don't match if the tail markers are escaped.
 
-## 7.0
+## [7.0](https://github.com/facelessuser/pymdown-extensions/releases/tag/7.0)
 
 Please see [Migration Notes](./releases/7.0.md) for details on upgrading to 7.0.
 
@@ -423,7 +423,7 @@ Please see [Migration Notes](./releases/7.0.md) for details on upgrading to 7.0.
 -   **FIX**: Numerous deprecation warnings associated with the recent release of Python Markdown 3.2.
 -   **FIX**: Ensure ExtraRawHTML raises a deprecation warning.
 
-## 6.3
+## [6.3](https://github.com/facelessuser/pymdown-extensions/releases/tag/6.3)
 
 -   **NEW**: `pymdownx.extrarawhtml` is now deprecated in favor of Python Markdown's `md_in_html` extension found in the
     3.2 release.
@@ -433,12 +433,12 @@ Please see [Migration Notes](./releases/7.0.md) for details on upgrading to 7.0.
 -   **NEW**: Remove deprecated `version` and `version_info`.
 -   **FIX**: Allow single word hostnames in MagicLink auto-link.
 
-## 6.2.1
+## [6.2.1](https://github.com/facelessuser/pymdown-extensions/releases/tag/6.2.1)
 
 -   **FIX**: Fix issue in PathConverter where Windows path conversion from relative to absolute doesn't always work in
     all browsers.
 
-## 6.2
+## [6.2](https://github.com/facelessuser/pymdown-extensions/releases/tag/6.2)
 
 -   **NEW**: Upgrade Twemoji to use 12.1.3.
 -   **NEW**: Downgrade and lock EmojiOne version 2.2.7. 2.2.7 is the last truly free version of EmojiOne. This is the
@@ -449,7 +449,7 @@ Please see [Migration Notes](./releases/7.0.md) for details on upgrading to 7.0.
 -   **FIX**: MagicLink: match the auto-link pattern in the current Markdown package.
 -   **FIX**: Fix fenced math escape issue when using MathJax script output format.
 
-## 6.1
+## [6.1](https://github.com/facelessuser/pymdown-extensions/releases/tag/6.1)
 
 -   **NEW**: Upgrade Twemoji to 12.1.2 using the latest JoyPixels' (formally EmojiOne) short name index in
     @JoyPixels/emoji-toolkit 5.0.4.
@@ -466,7 +466,7 @@ Please see [Migration Notes](./releases/7.0.md) for details on upgrading to 7.0.
 -   **FIX**: Fix for BetterEm case `**Strong*em,strong***`.
 -   **FIX**: Fixes for non-word character boundary cases in BetterEm, Caret, Mark, and Tilde extensions.
 
-## 6.0
+## [6.0](https://github.com/facelessuser/pymdown-extensions/releases/tag/6.0)
 
 Please see [Migration Notes](./releases/6.0.md) for details on upgrading to 6.0.0.
 
@@ -486,7 +486,7 @@ Please see [Migration Notes](./releases/6.0.md) for details on upgrading to 6.0.
 -   **FIX**: Remove unnecessary path code in B64.
 -   **FIX**: Fix issues with double escaping entities in code blocks after Python Markdown 3.0 update.
 
-## 5.0
+## [5.0](https://github.com/facelessuser/pymdown-extensions/releases/tag/5.0)
 
 -   **NEW**: Add validator to custom fences so custom options can be used. (!350)
 -   **NEW**: Add global `linenums_special` option to Highlight extension. Can be overridden per fence in SuperFences.
@@ -499,56 +499,56 @@ Please see [Migration Notes](./releases/6.0.md) for details on upgrading to 6.0.
 -   **FIX**: Add workaround in Highlight extension for line number alignment issues in Pygments with certain `step`
     values. (!360)
 
-## 4.12
+## [4.12](https://github.com/facelessuser/pymdown-extensions/releases/tag/4.12)
 
 -   **NEW**: Add option to fail if specified snippet isn't found. (#335)
 -   **FIX**: Windows issue with `preserve_tabs` option in SuperFences. (#328)
 
-## 4.11
+## [4.11](https://github.com/facelessuser/pymdown-extensions/releases/tag/4.11)
 
 -   **NEW**: Allow Arithmatex's "smart dollar" logic to be turned off via setting the option `smart_dollar` to `False`.
     (#297)
 -   **NEW**: Add support for tabbed groups in SuperFences.
 
-## 4.10.2
+## [4.10.2](https://github.com/facelessuser/pymdown-extensions/releases/tag/4.10.2)
 
 -   **FIX**: Failure with code highlight when guessing is enabled, but a bad language name is provided.
 
-## 4.10.1
+## [4.10.1](https://github.com/facelessuser/pymdown-extensions/releases/tag/4.10.1)
 
 -   **FIX**: Update Twemoji to 2.6.0 and EmojiOne 3.1.3.
 
-## 4.10
+## [4.10](https://github.com/facelessuser/pymdown-extensions/releases/tag/4.10)
 
 -   **NEW**: SuperFences now adds experimental support for preserving tabs in fenced code blocks. (#276)
 
-## 4.9.2
+## [4.9.2](https://github.com/facelessuser/pymdown-extensions/releases/tag/4.9.2)
 
 -   **FIX**: Issues with task lists that span multiple lines. (#267)
 -   **FIX**: Require latest Python Markdown.
 
-## 4.9.1
+## [4.9.1](https://github.com/facelessuser/pymdown-extensions/releases/tag/4.9.1)
 
 -   **FIX**: Output issue when no user and/or repository is specified.
 
-## 4.9
+## [4.9](https://github.com/facelessuser/pymdown-extensions/releases/tag/4.9)
 
 -   **NEW**: Add option to make task lists editable. (!249)
 -   **FIX**: Remove internal references to deprecated options.
 
-## 4.8
+## [4.8](https://github.com/facelessuser/pymdown-extensions/releases/tag/4.8)
 
 -   **NEW**: Set progress bar class level increments via `progress_increment` instead of using the hard coded value of
     `20`.
 -   **FIX**: Compatibility changes for next Markdown release.
 
-## 4.7
+## [4.7](https://github.com/facelessuser/pymdown-extensions/releases/tag/4.7)
 
 -   **NEW**: Bring back generic output for Arithmatex. Now under the `generic` option. (#185)
 -   **FIX**: StripHTML should allow space before close of opening tag.
 -   **FIX**: MagicLink should not auto-link inside a link. (#151)
 
-## 4.6
+## [4.6](https://github.com/facelessuser/pymdown-extensions/releases/tag/4.6)
 
 -   **NEW**: Arithmatex now *just* uses the script wrapper output as it is the most reliable output, and now previews
     can be achieved by providing a span with class `MathJax_Preview` that gets auto hidden when the math is rendered.
@@ -563,23 +563,23 @@ Please see [Migration Notes](./releases/6.0.md) for details on upgrading to 6.0.
     from style and script content. (!174)
 -   **FIX**: PlainHTML can strip attributes that are not quoted. (!174)
 
-## 4.5.1
+## [4.5.1](https://github.com/facelessuser/pymdown-extensions/releases/tag/4.5.1)
 
 -   **FIX**: If an invalid provider is given, default to `github`. If no `user` or `repo` is specified, do not convert
     links that depend on those default values. (#169)
 
-## 4.5
+## [4.5](https://github.com/facelessuser/pymdown-extensions/releases/tag/4.5)
 
 -   **NEW**: Add GitLab style compare link shorthand and link shortening. (#160)
 -   **NEW**: Deprecate GitHub extension. It is now recommended to just include the extensions you want to create a
     GitHub feel instead of relying on a an extension to package something close-ish. (#159)
 
-## 4.4
+## [4.4](https://github.com/facelessuser/pymdown-extensions/releases/tag/4.4)
 
 -   **NEW**: Add social media mentions -- Twitter only right now. (#156)
 -   **FIX**: Use correct regular expression for GitLab and Bitbucket.
 
-## 4.3
+## [4.3](https://github.com/facelessuser/pymdown-extensions/releases/tag/4.3)
 
 -   **NEW**: Shorthand format for referencing non-default provider commits, issues, pulls, and mentions. (!147)
 -   **NEW**: Shorthand format for mentioning a repo via `@user/repo`. (!149)
@@ -587,7 +587,7 @@ Please see [Migration Notes](./releases/6.0.md) for details on upgrading to 6.0.
 -   **NEW**: Make repository labels configurable. (!149)
 -   **FIX**: Adjust pattern boundaries auto-links.
 
-## 4.2
+## [4.2](https://github.com/facelessuser/pymdown-extensions/releases/tag/4.2)
 
 -   **NEW**: MagicLink can now auto-link a GitHub like shorthand for repository references. (!139)
 -   **NEW**: MagicLink now renders pull request links with a slightly different output from issues. (!139)
@@ -598,11 +598,11 @@ Please see [Migration Notes](./releases/6.0.md) for details on upgrading to 6.0.
 -   **FIX**: MagicLink repository link outputs now better reflect default user and repository context. (!143)
 -   **FIX**: PlainHTML should not strip tags that are part of JavaScript code. (!140)
 
-## 4.1
+## [4.1](https://github.com/facelessuser/pymdown-extensions/releases/tag/4.1)
 
 -   **NEW**: Details can now have multiple classes defined.
 
-## 4.0
+## [4.0](https://github.com/facelessuser/pymdown-extensions/releases/tag/4.0)
 
 -   **NEW**: Details extension will now derive a title from the class if only a class is provided. (#107)
 -   **NEW**: Remove deprecated legacy emoji generator format.
@@ -610,7 +610,7 @@ Please see [Migration Notes](./releases/6.0.md) for details on upgrading to 6.0.
 -   **NEW**: Remove deprecated `spoilers` extension redirect.
 -   **NEW**: Update emoji databases: EmojiOne (3.1.2) and Twemoji to .(2.5.0)
 
-## 3.5
+## [3.5](https://github.com/facelessuser/pymdown-extensions/releases/tag/3.5)
 
 -   **NEW**: Add new slugs to preserve case. (!103)
 -   **NEW**: Add new GFM specific slug (both percent encoded and normal) that only lowercases ASCII chars just like GFM
@@ -621,35 +621,35 @@ Please see [Migration Notes](./releases/6.0.md) for details on upgrading to 6.0.
     they will just pass through. (#95)
 -   **FIX**: Replace CriticMarkup placeholders after replacing raw HTML placeholders. (#95)
 
-## 3.4
+## [3.4](https://github.com/facelessuser/pymdown-extensions/releases/tag/3.4)
 
 -   **NEW**: Renamed Spoilers to Details
 -   **NEW**: No longer attach the `spoilers` class to `details` tags.
 -   **NEW**: Provide better example of UML script in documents.
 
-## 3.3
+## [3.3](https://github.com/facelessuser/pymdown-extensions/releases/tag/3.3)
 
 -   **NEW**: Added support for pull request link shortening in MagicLink. (!88)
 -   **NEW**: Added new Spoilers extension. (#85)
 
-## 3.2.1
+## [3.2.1](https://github.com/facelessuser/pymdown-extensions/releases/tag/3.2.1)
 
 -   **FIX**: Cannot set Highlight's CSS class.
 
-## 3.2
+## [3.2](https://github.com/facelessuser/pymdown-extensions/releases/tag/3.2)
 
 -   **NEW**: Add support for Twemoji 2.3.5.
 -   **NEW**: Update to EmojiOne 3.0.2.
 -   **NEW**: Emoji generators now also take `category` which is also no included in all indexes.
 -   **FIX**: Excessive new lines at end of code blocks.
 
-## 3.1
+## [3.1](https://github.com/facelessuser/pymdown-extensions/releases/tag/3.1)
 
 -   **NEW**: Highlight extension now runs normal indented code blocks through highlighter.
 -   **FIX**: When Pygments is disabled, `linenums` class was attached to code blocks even if `linenums` was disabled and
     not enabled via fence headers.
 
-## 3.0
+## [3.0](https://github.com/facelessuser/pymdown-extensions/releases/tag/3.0)
 
 -   **NEW**: Added Keys extension.
 -   **NEW**: Generalized custom fences (#60). `flow` and `sequence` fence are now just custom fences and can be disabled
@@ -668,7 +668,7 @@ Please see [Migration Notes](./releases/6.0.md) for details on upgrading to 6.0.
 -   **FIX**: Fix MathJax CDN references and usage in documentation.  MathJax CDN is shutting down and must now use
     Cloudflare CDN. (#63)
 
-## 2.0
+## [2.0](https://github.com/facelessuser/pymdown-extensions/releases/tag/2.0)
 
 -   **NEW**: SuperFences and InlineHilite can be configured via the new Highlight extension.
 -   **NEW**: InlineHilite now has all highlighting features pushed to the Highlight extension.  This removes all the
@@ -676,7 +676,7 @@ Please see [Migration Notes](./releases/6.0.md) for details on upgrading to 6.0.
 -   **NEW**: Deprecate the nesting option in SuperFences.  Nesting is default and the only acceptable behavior moving
     forward.  The ability to turn off nesting will be removed in 3.0.
 
-## 1.8
+## [1.8](https://github.com/facelessuser/pymdown-extensions/releases/tag/1.8)
 
 -   **NEW**: MagicLink special repository link shortener for GitHub, GitLab, and Bitbucket. (#49)
 -   **FIX**: GitHub asterisk emphasis should never have had smart enabled for it. (#50)
@@ -687,7 +687,7 @@ Please see [Migration Notes](./releases/6.0.md) for details on upgrading to 6.0.
     with it. (#48)
 -   **FIX**: InlineHilite will no longer break if Pygments is not installed (478b410a2199d55f3e70b452516511d3810c61a5).
 
-## 1.7
+## [1.7](https://github.com/facelessuser/pymdown-extensions/releases/tag/1.7)
 
 -   **NEW**: Arithmatex now supports `\(...\)`, `\[...\]`, and `\begin{}...\end{}`.
 -   **NEW**: Arithmatex has an option to embed the math code in MathJax script tags.
@@ -699,11 +699,11 @@ Please see [Migration Notes](./releases/6.0.md) for details on upgrading to 6.0.
 -   **FIX**: Update InlineHilite and SuperFences so that the language option can accept things like `c#` and `.net` etc.
 -   **FIX**: Snippets now removes carriage returns from imported files to prevent breakage.
 
-## 1.6.1
+## [1.6.1](https://github.com/facelessuser/pymdown-extensions/releases/tag/1.6.1)
 
 -   **FIX**: Don't install tools or tests folder when installing from Pypi.
 
-## 1.6
+## [1.6](https://github.com/facelessuser/pymdown-extensions/releases/tag/1.6)
 
 -   **NEW**: EscapeAll has the option to perform more like Pandoc in that you can enable escaped newlines to be
     `hardbreaks`, and escaped spaces to be `nbsp`.
@@ -712,7 +712,7 @@ Please see [Migration Notes](./releases/6.0.md) for details on upgrading to 6.0.
     them.
 -   **FIX**: Fix documentation issues.
 
-## 1.5
+## [1.5](https://github.com/facelessuser/pymdown-extensions/releases/tag/1.5)
 
 -   **NEW**: New EscapeAll extension.
 -   **NEW**: New Snippets extension for including external files into a Markdown file.
@@ -727,14 +727,14 @@ Please see [Migration Notes](./releases/6.0.md) for details on upgrading to 6.0.
     behavior.
 -   **FIX**: Critics shouldn't allow escaping critic marks as it is not in the spec.
 
-## 1.4
+## [1.4](https://github.com/facelessuser/pymdown-extensions/releases/tag/1.4)
 
 -   **NEW**: HeaderAnchor extension is now deprecated.  It will be removed in a future version.
 -   **NEW**: HeaderAnchor is no longer included in the `pymdownx.github` extension.
 -   **NEW**: Slugify functions are moved to `pymdownx.slug` in preparation of HeaderAnchor removal.
 -   **FIX**: GitHubEmoji is not "pending" deprecation, but is actually deprecated.
 
-## 1.3
+## [1.3](https://github.com/facelessuser/pymdown-extensions/releases/tag/1.3)
 
 -   **NEW**: New Emoji extension that aims to replace GitHubEmoji.  By default it is configured for EmojiOne and Gemoji
     (GitHub's emoji).
@@ -744,11 +744,11 @@ Please see [Migration Notes](./releases/6.0.md) for details on upgrading to 6.0.
 -   **NEW**: `github` extension now turns off `nl2br` by default in order properly emulate recent changes in GFM.
     `no_nl2br` option is deprecated and will be removed in the future as it no longer reflects GFM behavior.
 
-## 1.2
+## [1.2](https://github.com/facelessuser/pymdown-extensions/releases/tag/1.2)
 
 -   **NEW**: Add option to output task lists in a more customizable way.
 
-## 1.1
+## [1.1](https://github.com/facelessuser/pymdown-extensions/releases/tag/1.1)
 
 -   **NEW**: Add pypi 3.5 info in setup
 -   **NEW**: Add option to MagicLink extension to allow the stripping of link protocols (`http://` etc.).
@@ -756,10 +756,10 @@ Please see [Migration Notes](./releases/6.0.md) for details on upgrading to 6.0.
     Markdown.  Currently the default is the legacy (uses `nl2br`), but a warning will be displayed.  In the future, the
     option will be defaulted to not use `nl2br`.
 
-## 1.0.1
+## [1.0.1](https://github.com/facelessuser/pymdown-extensions/releases/tag/1.0.1)
 
 -   **FIX**: Ordinal number 11th, 12th, and 13th
 
-## 1.0.0
+## [1.0.0](https://github.com/facelessuser/pymdown-extensions/releases/tag/1.0.0)
 
 -   **NEW**: Initial release.


### PR DESCRIPTION
You can view the test release at https://github.com/Goooler/pymdown-extensions/releases/tag/10.14.3