### PR TITLE
Add support for headings in details summaries

### DIFF
--- a/pymdownx/blocks/details.py
+++ b/pymdownx/blocks/details.py
@@ -5,6 +5,7 @@ from ..blocks import BlocksExtension
 import re
 
 RE_SEP = re.compile(r'[_-]+')
+RE_HEADING = re.compile(r'^(?P<level>#{1,6})(?P<header>(?:\\.|[^\\])*?)#*$')
 
 
 class Details(Block):
@@ -81,7 +82,12 @@ class Details(Block):
         # Create the summary
         if summary is not None:
             s = etree.SubElement(el, 'summary')
-            s.text = summary
+            m = RE_HEADING.match(summary)
+            if m:
+                h = etree.SubElement(s, f'h{len(m.group('level'))}')
+                h.text = m.group('header').strip()
+            else:
+                s.text = summary
 
         return el
 

--- a/tests/test_extensions/test_blocks/test_details.py
+++ b/tests/test_extensions/test_blocks/test_details.py
@@ -76,6 +76,26 @@ class TestBlocksDetails(util.MdCase):
             True
         )
 
+    def test_heading_in_title(self):
+        """Test details with heading in title."""
+
+        self.check_markdown(
+            R'''
+            /// details | ## A Title
+            Some *content*
+            ///
+            ''',
+            r'''
+            <details>
+            <summary>
+            <h2>A Title</h2>
+            </summary>
+            <p>Some <em>content</em></p>
+            </details>
+            ''',
+            True
+        )
+
     def test_details(self):
         """Test details with title."""
 


### PR DESCRIPTION
I implemented the heading-only behavior as you requested. It wasn't difficult. I just copied and modified the regex for hash-heading to not check for lines before/after as there is never going to be multiple lines within a detail title.